### PR TITLE
Editor polish: selection highlight, timeline word pills, wordmark logo, monotonic progress

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,19 @@ body {
   background: rgba(99, 102, 241, 0.25);
 }
 
+/*
+ * Custom transcript selection highlight: the native ::selection is made
+ * transparent over the words (see TranscriptPanel) and selected word spans
+ * are marked with [data-sel] instead, producing a dimmed, continuous
+ * highlight that includes the spaces between words.
+ */
+.transcript-words [data-wid][data-sel] {
+  background-color: rgb(199 210 254 / 0.5);
+}
+.transcript-words [data-wid][data-sel].word-deleted {
+  background-color: rgb(254 202 202 / 0.7);
+}
+
 /* Slim scrollbars for panels and the timeline */
 .scrollbar-thin {
   scrollbar-width: thin;

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -9,7 +9,6 @@ import UploadScreen from "./UploadScreen";
 import TranscriptPanel from "./TranscriptPanel";
 import VideoPreview from "./VideoPreview";
 import Timeline from "./Timeline";
-import SideRail from "./SideRail";
 import ExportDialog from "./ExportDialog";
 
 export default function Editor() {
@@ -72,7 +71,7 @@ export default function Editor() {
             <div className="flex w-[44%] min-w-[320px] shrink-0 flex-col border-l border-zinc-200">
               <VideoPreview />
             </div>
-            <SideRail />
+            {/* <SideRail /> — hidden until the tools it exposes are functional */}
           </div>
           <Timeline />
         </>

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -209,13 +209,17 @@ export default function Timeline() {
             {visibleWords.map((w) => (
               <span
                 key={w.id}
-                className={`absolute overflow-hidden text-[10px] whitespace-nowrap ${
-                  w.deleted ? "text-red-400 line-through" : "text-zinc-500"
+                title={w.text}
+                className={`absolute block overflow-hidden rounded-sm border px-1 text-[10px] leading-[14px] text-ellipsis whitespace-nowrap ${
+                  w.deleted
+                    ? "border-red-200 bg-red-50 text-red-400 line-through"
+                    : "border-zinc-200 bg-white text-zinc-600"
                 }`}
                 style={{
-                  left: w.start * pps + 1,
-                  top: RULER_H + 3,
-                  maxWidth: Math.max(6, (w.end - w.start) * pps + 24),
+                  left: w.start * pps,
+                  top: RULER_H + 2,
+                  width: Math.max(5, (w.end - w.start) * pps - 1),
+                  height: 16,
                 }}
               >
                 {w.text}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -22,14 +22,9 @@ export default function TopBar() {
       >
         <Home size={16} />
       </button>
-      <div className="flex items-center gap-1.5 pl-1">
-        <div className="flex h-6 w-6 items-center justify-center rounded-md bg-gradient-to-br from-indigo-500 to-violet-600 text-[13px] font-bold text-white">
-          R
-        </div>
-        <span className="text-sm font-semibold tracking-tight text-zinc-800">
-          Rescript
-        </span>
-      </div>
+      <span className="pl-1 text-sm font-semibold tracking-tight text-zinc-800">
+        Rescript
+      </span>
 
       <div className="pointer-events-none absolute left-1/2 hidden -translate-x-1/2 items-center text-[13px] text-zinc-500 sm:flex">
         {videoFile ? videoFile.name : "Untitled project"}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -26,9 +26,11 @@ export default function TopBar() {
         Rescript
       </span>
 
-      <div className="pointer-events-none absolute left-1/2 hidden -translate-x-1/2 items-center text-[13px] text-zinc-500 sm:flex">
-        {videoFile ? videoFile.name : "Untitled project"}
-      </div>
+      {videoFile && (
+        <div className="pointer-events-none absolute left-1/2 hidden -translate-x-1/2 items-center text-[13px] text-zinc-500 sm:flex">
+          {videoFile.name}
+        </div>
+      )}
 
       <div className="ml-auto flex items-center gap-1">
         <button

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -44,22 +44,22 @@ const WordSpan = memo(function WordSpan({
   active: boolean;
   onClick: (word: Word) => void;
 }) {
+  // The trailing space lives inside the span so that selection and deletion
+  // highlights are continuous across words instead of breaking at each gap.
   return (
-    <>
-      <span
-        data-wid={word.id}
-        onClick={() => onClick(word)}
-        className={`cursor-pointer rounded px-px transition-colors duration-75 ${
-          word.deleted
-            ? "bg-red-50 text-red-400 line-through decoration-red-300"
-            : active
-              ? "bg-indigo-200/80 text-zinc-900"
-              : "text-zinc-800 hover:bg-indigo-50"
-        }`}
-      >
-        {word.text}
-      </span>{" "}
-    </>
+    <span
+      data-wid={word.id}
+      onClick={() => onClick(word)}
+      className={`cursor-pointer transition-colors duration-75 ${
+        word.deleted
+          ? "word-deleted bg-red-50 text-red-400 line-through decoration-red-300"
+          : active
+            ? "bg-indigo-200/80 text-zinc-900"
+            : "text-zinc-800 hover:bg-indigo-50"
+      }`}
+    >
+      {word.text}{" "}
+    </span>
   );
 });
 
@@ -106,17 +106,27 @@ export default function TranscriptPanel() {
     setCurrentTime(word.start + 0.001);
   }, []);
 
-  // Track text selection over word spans and position the floating toolbar.
+  // Track text selection over word spans, position the floating toolbar, and
+  // paint our own (dimmed, gap-free) highlight by marking the selected spans.
+  // The native ::selection highlight is made transparent over the words, and
+  // the marking is done imperatively so dragging doesn't re-render the panel.
+  const markedRef = useRef<Set<HTMLElement>>(new Set());
   useEffect(() => {
+    const clearMarks = () => {
+      for (const el of markedRef.current) el.removeAttribute("data-sel");
+      markedRef.current.clear();
+    };
     const handler = () => {
       const container = containerRef.current;
       const sel = window.getSelection();
       if (!container || !sel || sel.isCollapsed || sel.rangeCount === 0) {
+        clearMarks();
         setSelection(null);
         return;
       }
       const range = sel.getRangeAt(0);
       if (!container.contains(range.commonAncestorContainer)) {
+        clearMarks();
         setSelection(null);
         return;
       }
@@ -124,15 +134,22 @@ export default function TranscriptPanel() {
       const ids: number[] = [];
       let anyDeleted = false;
       let anyKept = false;
+      const marked = new Set<HTMLElement>();
       container.querySelectorAll<HTMLElement>("[data-wid]").forEach((el) => {
         if (range.intersectsNode(el)) {
           const id = Number(el.dataset.wid);
           ids.push(id);
+          el.setAttribute("data-sel", "");
+          marked.add(el);
           const w = wordMap.get(id);
           if (w?.deleted) anyDeleted = true;
           else anyKept = true;
         }
       });
+      for (const el of markedRef.current) {
+        if (!marked.has(el)) el.removeAttribute("data-sel");
+      }
+      markedRef.current = marked;
       if (ids.length === 0) {
         setSelection(null);
         return;
@@ -148,7 +165,10 @@ export default function TranscriptPanel() {
       });
     };
     document.addEventListener("selectionchange", handler);
-    return () => document.removeEventListener("selectionchange", handler);
+    return () => {
+      clearMarks();
+      document.removeEventListener("selectionchange", handler);
+    };
   }, [words]);
 
   const cutSelection = useCallback(() => {
@@ -259,31 +279,34 @@ export default function TranscriptPanel() {
             </div>
           )}
 
-          {status === "ready" &&
-            turns.map((turn, i) => {
-              const visible = showDeleted ? turn.words : turn.words.filter((w) => !w.deleted);
-              if (visible.length === 0) return null;
-              return (
-                <div key={i} className="mb-7">
-                  <div
-                    className="mb-1.5 text-[13px] font-semibold"
-                    style={{ color: speakerColor(turn.speaker) }}
-                  >
-                    Speaker {turn.speaker + 1}
+          {status === "ready" && (
+            <div className="transcript-words selection:bg-transparent">
+              {turns.map((turn, i) => {
+                const visible = showDeleted ? turn.words : turn.words.filter((w) => !w.deleted);
+                if (visible.length === 0) return null;
+                return (
+                  <div key={i} className="mb-7">
+                    <div
+                      className="mb-1.5 text-[13px] font-semibold"
+                      style={{ color: speakerColor(turn.speaker) }}
+                    >
+                      Speaker {turn.speaker + 1}
+                    </div>
+                    <p className="select-text text-[15px] leading-8">
+                      {visible.map((w) => (
+                        <WordSpan
+                          key={w.id}
+                          word={w}
+                          active={w.id === activeWordId}
+                          onClick={seekToWord}
+                        />
+                      ))}
+                    </p>
                   </div>
-                  <p className="select-text text-[15px] leading-8">
-                    {visible.map((w) => (
-                      <WordSpan
-                        key={w.id}
-                        word={w}
-                        active={w.id === activeWordId}
-                        onClick={seekToWord}
-                      />
-                    ))}
-                  </p>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
+          )}
 
           {selection && (
             <div

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -259,10 +259,6 @@ export default function TranscriptPanel() {
                     />
                   </div>
                 )}
-                <p className="mt-2 text-xs text-zinc-400">
-                  Everything runs locally in your browser — this can take a while on
-                  first use while models are cached.
-                </p>
               </div>
               {partialText && (
                 <p className="text-[15px] leading-8 text-zinc-400">

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -24,9 +24,6 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
     <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-zinc-50 to-indigo-50/50 p-6">
       <div className="w-full max-w-xl">
         <div className="mb-8 flex flex-col items-center text-center">
-          <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 to-violet-600 text-2xl font-bold text-white shadow-lg shadow-indigo-200">
-            R
-          </div>
           <h1 className="text-3xl font-bold tracking-tight text-zinc-900">Rescript</h1>
           <p className="mt-2 max-w-md text-[15px] leading-relaxed text-zinc-500">
             Edit video by editing text. Delete a word in the transcript and it&apos;s cut

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -32,9 +32,18 @@ const DIARIZATION_MODEL = "onnx-community/pyannote-segmentation-3.0";
 const post = (msg: WorkerResponse, transfer: Transferable[] = []) =>
   (self as unknown as Worker).postMessage(msg, transfer);
 
-/** Aggregate multi-file download progress into a single 0..1 value. */
+/**
+ * Aggregate multi-file download progress into a single 0..1 value.
+ *
+ * Files are discovered progressively, so the naive loaded/total ratio can
+ * *drop* whenever a new file starts reporting (the denominator suddenly
+ * grows). The reported value is therefore clamped to be monotonically
+ * increasing: it may pause while a newly discovered file catches up, but it
+ * never goes backwards.
+ */
 function makeDownloadTracker(label: string) {
   const files = new Map<string, { loaded: number; total: number }>();
+  let best = 0;
   return (p: { status?: string; file?: string; loaded?: number; total?: number }) => {
     if (p.status !== "progress" || !p.file || !p.total) return;
     files.set(p.file, { loaded: p.loaded ?? 0, total: p.total });
@@ -44,11 +53,9 @@ function makeDownloadTracker(label: string) {
       loaded += f.loaded;
       total += f.total;
     }
-    post({
-      type: "progress",
-      message: label,
-      value: total > 0 ? loaded / total : null,
-    });
+    if (total === 0) return;
+    best = Math.max(best, Math.min(1, loaded / total));
+    post({ type: "progress", message: label, value: best });
   };
 }
 
@@ -166,14 +173,20 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
     const tokenizer = transcriber.tokenizer as ConstructorParameters<
       typeof WhisperTextStreamer
     >[0];
+    // Chunk start times can jitter around stride boundaries; clamp the
+    // reported transcription progress so it only ever moves forward.
+    let transcribed = 0;
     const streamer = new WhisperTextStreamer(tokenizer, {
       skip_prompt: true,
       time_precision: timePrecision,
       on_chunk_start: (t: number) => {
+        if (duration > 0) {
+          transcribed = Math.max(transcribed, Math.min(1, t / duration));
+        }
         post({
           type: "progress",
           message: "Transcribing…",
-          value: duration > 0 ? Math.min(1, t / duration) : null,
+          value: duration > 0 ? transcribed : null,
         });
       },
       callback_function: (text: string) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

UX improvements to the editor, following up on #1:

1. **Continuous, dimmed selection highlight** — the trailing space now lives inside each word span and the native `::selection` is made transparent over the transcript; selected spans are instead marked imperatively (`data-sel`, no React re-render while dragging) and styled with a dim indigo background, so the highlight is continuous across word gaps instead of showing breaks. Deleted words in a selection get a matching dim red. A side benefit: the strikethrough on deleted phrases is now continuous too.

[Continuous dimmed selection highlight](https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4/artifacts?path=%2Ftmp%2Fe2e%2Fshots%2Fv2-selection.png)

2. **Readable timeline word labels** — words on the timeline are now Descript-style pills: white background, border, and ellipsis truncation, sized exactly to each word's duration so they never overlap. Cut words render as red pills over the red cut region.

[Timeline word pills with cut region](https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4/artifacts?path=%2Ftmp%2Fe2e%2Fshots%2Fv4-timeline-cut.png)

3. **Logo** — removed the gradient "R" block from both the top bar and the upload screen; the "Rescript" wordmark is the logo.

4. **Monotonic progress** — model download percentage used to drop whenever a new file was discovered mid-download (the aggregate denominator suddenly grew); the tracker now clamps the reported value to be monotonically increasing. Transcription progress from chunk start times is clamped the same way.

5. **UI cleanup** — removed the "runs locally / models are cached" note from the progress card, hid the decorative right-hand tool rail until its tools are functional, and the top bar only shows a project title once a file is loaded (no more "Untitled project" on the homepage).

[Editor after cleanup: no side rail, filename title](https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4/artifacts?path=%2Ftmp%2Fe2e%2Fshots%2Fw3-editor.png)

## Testing

Verified in headless Chromium against a production build: selection renders as one continuous dim band including spaces; zoomed and fit timeline views show truncated pills; progress sampled every 150 ms during a full transcription showed zero backward movement within a stage; homepage shows no title, the filename appears after upload, the caching note is gone, and the side rail is hidden. `npm run lint` and `npm run build` pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

