### PR TITLE
Add Google Analytics (G-WZ055S858C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ it is transcribed locally with per-word timestamps and speaker labels. Delete
 words in the transcript and the corresponding clip is cut from the video.
 Export the final cut to MP4 — without your video ever leaving your device.
 
-- 🔒 **Private by design** — no server, no auth, no API calls, no uploads
+- 🔒 **Private by design** — no server, no auth, no uploads; all media processing happens on-device
 - 📝 **Word-level editing** — select words, press ⌫, the cut follows the text
 - 🗣️ **Speaker diarization** — the transcript is grouped by speaker
 - 🎬 **Timeline** — waveform, word labels, cut regions, playhead, zoom
@@ -37,7 +37,9 @@ audio track.
 > **Note on "offline":** the AI models (~90 MB total) are downloaded from the
 > Hugging Face Hub the *first* time you transcribe, then cached in browser
 > storage. After that, everything — transcription, editing, export — works with
-> the network fully disconnected. The app itself never makes API calls.
+> the network fully disconnected. Your media and transcript never leave the
+> device; the only third-party request the app makes is anonymous page
+> analytics (Google Analytics), which fails silently when offline.
 
 ## How it works
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -29,6 +30,7 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full">{children}</body>
+      <GoogleAnalytics gaId="G-WZ055S858C" />
     </html>
   );
 }

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -84,7 +84,7 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
 
         <p className="mt-6 flex items-center justify-center gap-1.5 text-center text-xs text-zinc-400">
           <Lock size={12} />
-          No uploads, no accounts, no API calls — your video never leaves this device.
+          No uploads, no accounts — your video never leaves this device.
         </p>
       </div>
     </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,13 +4,16 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   // SharedArrayBuffer (required by ffmpeg.wasm multi-threading and onnxruntime
   // multi-threading) is only available in cross-origin-isolated contexts.
+  // COEP "credentialless" (rather than "require-corp") keeps the page
+  // cross-origin isolated while still allowing third-party scripts like
+  // Google Analytics, which don't send Cross-Origin-Resource-Policy headers.
   async headers() {
     return [
       {
         source: "/(.*)",
         headers: [
           { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
-          { key: "Cross-Origin-Embedder-Policy", value: "require-corp" },
+          { key: "Cross-Origin-Embedder-Policy", value: "credentialless" },
         ],
       },
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
-  "name": "rescript-scaffold",
+  "name": "rescript",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rescript-scaffold",
+      "name": "rescript",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@ffmpeg/core-mt": "^0.12.10",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "@huggingface/transformers": "^4.2.0",
+        "@next/third-parties": "^16.2.12",
         "lucide-react": "^1.27.0",
         "next": "16.2.12",
         "react": "19.2.4",
@@ -1268,6 +1270,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.12.tgz",
+      "integrity": "sha512-1fHKgERSVcgC0QfPJq2v96l6pLUdbVdkT0bjJYK8MguKTVjPd734kWBxfd77nPUG4N5F9s+qVdVjpEBm1tlwNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6536,6 +6551,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "@huggingface/transformers": "^4.2.0",
+    "@next/third-parties": "^16.2.12",
     "lucide-react": "^1.27.0",
     "next": "16.2.12",
     "react": "19.2.4",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Google Analytics 4 with measurement ID `G-WZ055S858C`, injected via `@next/third-parties`' `GoogleAnalytics` component in the root layout.

## COEP change

GA's script and beacons carry no `Cross-Origin-Resource-Policy` headers, so they are blocked under our `Cross-Origin-Embedder-Policy: require-corp`. This PR switches COEP to `credentialless`, which still keeps the page **cross-origin isolated** (so `SharedArrayBuffer` and multi-threaded ffmpeg.wasm / onnxruntime keep working) while allowing credential-free third-party requests like GA.

Also updates the README and upload-screen privacy wording: media and transcripts stay on-device; the only third-party request the app makes is anonymous page analytics.

## Testing

Verified in headless Chromium against a production build:

- `crossOriginIsolated` is still `true` under `credentialless`
- `https://www.googletagmanager.com/gtag/js?id=G-WZ055S858C` loads with a 200 and `gtag`/`dataLayer` are defined
- The GA4 `collect` pageview beacon returns 204 (accepted)
- The full pipeline (ffmpeg audio extraction → Whisper transcription → diarization) still works: 39 words transcribed
- `npm run lint` and `npm run build` pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

