### PR TITLE
Cache-aware progress labels + preload speaker model during transcription

### DIFF
--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -59,6 +59,22 @@ function makeDownloadTracker(label: string) {
   };
 }
 
+/**
+ * Whether a model's weights are already in the transformers.js browser cache.
+ * Used purely to label the progress UI accurately ("Loading … from cache"
+ * instead of "Downloading …"): transformers.js emits identical progress
+ * events when reading a cached model from disk as when downloading it.
+ */
+async function isModelCached(modelId: string): Promise<boolean> {
+  try {
+    const cache = await caches.open(env.cacheKey ?? "transformers-cache");
+    const keys = await cache.keys();
+    return keys.some((req) => req.url.includes(modelId) && req.url.includes(".onnx"));
+  } catch {
+    return false;
+  }
+}
+
 async function pickDevice(): Promise<"webgpu" | "wasm"> {
   try {
     const gpu = (globalThis.navigator as Navigator & {
@@ -76,17 +92,20 @@ async function getAsr() {
   if (!asrPromise) {
     const device = await pickDevice();
     const dtype = { encoder_model: "fp32", decoder_model_merged: "q4" } as const;
+    const label = (await isModelCached(ASR_MODEL))
+      ? "Loading speech model from cache…"
+      : "Downloading speech model…";
     asrPromise = pipeline("automatic-speech-recognition", ASR_MODEL, {
       dtype,
       device,
-      progress_callback: makeDownloadTracker("Downloading speech model…"),
+      progress_callback: makeDownloadTracker(label),
     }).catch((err) => {
       // WebGPU can fail on some drivers; retry once on plain WASM.
       if (device === "webgpu") {
         return pipeline("automatic-speech-recognition", ASR_MODEL, {
           dtype,
           device: "wasm",
-          progress_callback: makeDownloadTracker("Downloading speech model…"),
+          progress_callback: makeDownloadTracker(label),
         });
       }
       throw err;
@@ -102,16 +121,38 @@ interface DiarizationSegment {
   confidence: number;
 }
 
+type Diarizer = {
+  processor: Awaited<ReturnType<typeof AutoProcessor.from_pretrained>>;
+  model: Awaited<ReturnType<typeof AutoModelForAudioFrameClassification.from_pretrained>>;
+};
+
+/**
+ * Load the diarization model. Started in the background while Whisper is
+ * still transcribing, so the (small) speaker model is downloaded, cached,
+ * and ready by the time the transcript lands — closing the tab right after
+ * transcription no longer leaves it uncached for the next session. No
+ * progress is posted here to avoid interleaving with transcription progress.
+ */
+let diarizerPromise: Promise<Diarizer> | null = null;
+function getDiarizer(): Promise<Diarizer> {
+  if (!diarizerPromise) {
+    diarizerPromise = (async () => {
+      const processor = await AutoProcessor.from_pretrained(DIARIZATION_MODEL, {});
+      const model = await AutoModelForAudioFrameClassification.from_pretrained(
+        DIARIZATION_MODEL,
+        { dtype: "fp32" }
+      );
+      return { processor, model };
+    })();
+    diarizerPromise.catch(() => {
+      diarizerPromise = null;
+    });
+  }
+  return diarizerPromise;
+}
+
 async function diarize(audio: Float32Array): Promise<DiarizationSegment[]> {
-  const progress = makeDownloadTracker("Downloading speaker model…");
-  const processor = await AutoProcessor.from_pretrained(DIARIZATION_MODEL, {
-    progress_callback: progress,
-  });
-  const model = await AutoModelForAudioFrameClassification.from_pretrained(
-    DIARIZATION_MODEL,
-    { dtype: "fp32", progress_callback: progress }
-  );
-  post({ type: "progress", message: "Identifying speakers…", value: null });
+  const { processor, model } = await getDiarizer();
   const inputs = await processor(audio);
   const { logits } = await model(inputs);
   // post_process_speaker_diarization is specific to the PyAnnote processor
@@ -159,6 +200,9 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
   const { audio, duration, language } = event.data;
   try {
     const transcriber = await getAsr();
+    // Warm up the speaker model in parallel with transcription (errors are
+    // handled when it is awaited later; this avoids an unhandled rejection).
+    getDiarizer().catch(() => {});
     post({ type: "progress", message: "Transcribing…", value: 0 });
 
     let partial = "";
@@ -227,6 +271,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
     // Best-effort speaker diarization; a failure should not lose the transcript.
     try {
+      post({ type: "progress", message: "Identifying speakers…", value: null });
       const segments = await diarize(audio);
       assignSpeakers(words, segments);
     } catch (err) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the report that models appear to re-download on every visit.

## Investigation: caching works

Reproduced against the GitHub Pages simulation (static export + COI service worker) with two consecutive visits in the same profile:

- **Run 1 (cold):** ~206 MB downloaded from Hugging Face, 10 entries written to the `transformers-cache` Cache Storage
- **Run 2 (warm):** exactly **one** HF request — a 1-byte `Range: bytes=0-0` metadata probe transformers.js uses for progress sizing — and zero model downloads

This matches the DevTools screenshot from the report: 167 MB of "resources" but only 6 MB actually "transferred". Two things made caching *look* broken:

1. **The UI said "Downloading speech model…" even for cache reads.** transformers.js emits identical progress events when reading a cached model from disk as when downloading it.
2. **The ~6 MB that really did transfer was the pyannote speaker model.** It only loaded *after* transcription finished, so closing the tab as soon as the transcript appeared left it uncached, and it re-downloaded next session. (Also note: Cache Storage is per-origin — models cached on `localhost` don't carry over to the deployed site, so the first deployed visit downloads everything once.)

## Changes

- The worker checks the browser cache before loading Whisper and labels the progress accordingly: **"Loading speech model from cache…"** vs **"Downloading speech model…"**
- The diarization model now warms up **in parallel with transcription** (progress-silent to avoid interleaving with the transcription progress bar), so it is downloaded and cached by the time the transcript lands — and total processing is a few seconds faster

## Testing

Two-visit diagnostic against the static-export/service-worker setup:

- Run 1: labels show "Downloading speech model…"; all 10 cache entries (incl. pyannote) present at transcript-ready
- Run 2: labels show "Loading speech model from cache…"; 1 HF request (1 byte), 0 large downloads
- `npm run lint` and the static-export build pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

