### PR TITLE
Add word correction (edit transcript text)

### DIFF
--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, Home, Redo2, Scissors, Undo2 } from "lucide-react";
+import { Download, Home, Redo2, Undo2 } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 
 export default function TopBar() {

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Eye, EyeOff, RotateCcw, Scissors } from "lucide-react";
+import { Eye, EyeOff, Pencil, RotateCcw, Scissors, X } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import type { SpeakerTurn, Word } from "@/lib/types";
 
@@ -81,12 +81,23 @@ export default function TranscriptPanel() {
   const toggleShowDeleted = useEditorStore((s) => s.toggleShowDeleted);
   const deleteWords = useEditorStore((s) => s.deleteWords);
   const restoreWords = useEditorStore((s) => s.restoreWords);
+  const correctWords = useEditorStore((s) => s.correctWords);
   const playing = useEditorStore((s) => s.playing);
   const activeWordId = useEditorStore((s) => findActiveWordId(s.words, s.currentTime));
 
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
+  const [correcting, setCorrecting] = useState<{
+    ids: number[];
+    top: number;
+    left: number;
+    containerWidth: number;
+  } | null>(null);
+  const [correctText, setCorrectText] = useState("");
+  // Mirrors `correcting` so the selectionchange handler (which has its own
+  // dependency list) can freeze the highlight while the popover is open.
+  const correctingRef = useRef(false);
 
   const turns = useMemo<SpeakerTurn[]>(() => {
     const out: SpeakerTurn[] = [];
@@ -117,6 +128,8 @@ export default function TranscriptPanel() {
       markedRef.current.clear();
     };
     const handler = () => {
+      // Keep the highlight frozen on the words being corrected.
+      if (correctingRef.current) return;
       const container = containerRef.current;
       const sel = window.getSelection();
       if (!container || !sel || sel.isCollapsed || sel.rangeCount === 0) {
@@ -184,6 +197,49 @@ export default function TranscriptPanel() {
     window.getSelection()?.removeAllRanges();
     setSelection(null);
   }, [selection, restoreWords]);
+
+  const openCorrect = useCallback(() => {
+    if (!selection) return;
+    const idSet = new Set(selection.ids);
+    const text = words
+      .filter((w) => idSet.has(w.id))
+      .map((w) => w.text)
+      .join(" ");
+    correctingRef.current = true;
+    setCorrectText(text);
+    setCorrecting({
+      ids: selection.ids,
+      top: selection.top,
+      left: selection.left,
+      containerWidth: containerRef.current?.clientWidth ?? 640,
+    });
+    setSelection(null);
+    window.getSelection()?.removeAllRanges();
+  }, [selection, words]);
+
+  const closeCorrect = useCallback(() => {
+    correctingRef.current = false;
+    for (const el of markedRef.current) el.removeAttribute("data-sel");
+    markedRef.current.clear();
+    setCorrecting(null);
+  }, []);
+
+  const applyCorrection = useCallback(() => {
+    if (!correcting) return;
+    correctWords(correcting.ids, correctText);
+    closeCorrect();
+  }, [correcting, correctText, correctWords, closeCorrect]);
+
+  // Close the correction popover when clicking outside of it.
+  const popoverRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!correcting) return;
+    const handler = (e: MouseEvent) => {
+      if (!popoverRef.current?.contains(e.target as Node)) closeCorrect();
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [correcting, closeCorrect]);
 
   // Delete / Backspace cuts the selected words.
   useEffect(() => {
@@ -304,7 +360,7 @@ export default function TranscriptPanel() {
             </div>
           )}
 
-          {selection && (
+          {selection && !correcting && (
             <div
               className="absolute z-20 flex -translate-x-1/2 items-center gap-0.5 rounded-xl border border-zinc-200 bg-white p-1 shadow-lg shadow-zinc-900/10"
               style={{ top: selection.top, left: selection.left }}
@@ -319,6 +375,13 @@ export default function TranscriptPanel() {
                   Cut
                 </button>
               )}
+              <button
+                onClick={openCorrect}
+                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[13px] font-medium text-zinc-700 transition hover:bg-zinc-100"
+              >
+                <Pencil size={13} />
+                Correct
+              </button>
               {selection.anyDeleted && (
                 <button
                   onClick={restoreSelection}
@@ -328,6 +391,50 @@ export default function TranscriptPanel() {
                   Restore
                 </button>
               )}
+            </div>
+          )}
+
+          {correcting && (
+            <div
+              ref={popoverRef}
+              className="absolute z-20 w-80 max-w-[calc(100%-16px)] -translate-x-1/2 rounded-2xl border border-zinc-200 bg-white p-3 shadow-xl shadow-zinc-900/10"
+              style={{
+                top: Math.max(4, correcting.top - 56),
+                left: Math.min(
+                  Math.max(168, correcting.left),
+                  correcting.containerWidth - 168
+                ),
+              }}
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-[13px] font-semibold text-zinc-800">Correct</span>
+                <button
+                  onClick={closeCorrect}
+                  className="flex h-6 w-6 items-center justify-center rounded-md text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700"
+                >
+                  <X size={13} />
+                </button>
+              </div>
+              <input
+                autoFocus
+                value={correctText}
+                onChange={(e) => setCorrectText(e.target.value)}
+                onFocus={(e) => e.currentTarget.select()}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") applyCorrection();
+                  else if (e.key === "Escape") closeCorrect();
+                }}
+                className="w-full rounded-lg border border-zinc-300 bg-zinc-50 px-2.5 py-1.5 text-sm text-zinc-800 outline-none focus:border-zinc-500 focus:bg-white"
+              />
+              <div className="mt-2.5 flex justify-end">
+                <button
+                  onClick={applyCorrection}
+                  disabled={correctText.trim().length === 0}
+                  className="flex h-8 items-center rounded-full bg-zinc-900 px-4 text-[13px] font-medium text-white transition hover:bg-zinc-700 disabled:opacity-40"
+                >
+                  Correct
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -44,6 +44,8 @@ interface EditorState {
   setWords: (words: Word[]) => void;
   deleteWords: (ids: number[]) => void;
   restoreWords: (ids: number[]) => void;
+  /** Replace the selected (contiguous) words with corrected text. */
+  correctWords: (ids: number[], text: string) => void;
   undo: () => void;
   redo: () => void;
   toggleShowDeleted: () => void;
@@ -121,6 +123,53 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       past: [...past, words],
       future: [],
       words: words.map((w) => (idSet.has(w.id) && w.deleted ? { ...w, deleted: false } : w)),
+    });
+  },
+  correctWords: (ids, text) => {
+    const { words, past } = get();
+    const tokens = text.split(/\s+/).filter(Boolean);
+    if (ids.length === 0 || tokens.length === 0) return;
+    const idSet = new Set(ids);
+    const indices = words.reduce<number[]>((acc, w, i) => {
+      if (idSet.has(w.id)) acc.push(i);
+      return acc;
+    }, []);
+    if (indices.length === 0) return;
+    // Replace the whole contiguous slice covered by the selection.
+    const from = indices[0];
+    const to = indices[indices.length - 1];
+    const selected = words.slice(from, to + 1);
+    if (selected.map((w) => w.text).join(" ") === tokens.join(" ")) return;
+
+    // Distribute the original time span across the new words in proportion
+    // to their character length.
+    const spanStart = selected[0].start;
+    const spanEnd = selected[selected.length - 1].end;
+    const span = Math.max(0.02, spanEnd - spanStart);
+    const totalChars = tokens.reduce((acc, t) => acc + t.length, 0);
+    let nextId = words.reduce((m, w) => Math.max(m, w.id), 0) + 1;
+    let cursor = spanStart;
+    const replacement: Word[] = tokens.map((t) => {
+      const dur = (span * t.length) / totalChars;
+      const word: Word = {
+        id: nextId++,
+        text: t,
+        start: cursor,
+        end: Math.min(spanEnd, cursor + dur),
+        speaker: selected[0].speaker,
+        // A correction implies the words are wanted, unless the whole
+        // selection was already cut.
+        deleted: selected.every((w) => w.deleted),
+      };
+      cursor = word.end;
+      return word;
+    });
+    replacement[replacement.length - 1].end = spanEnd;
+
+    set({
+      past: [...past, words],
+      future: [],
+      words: [...words.slice(0, from), ...replacement, ...words.slice(to + 1)],
     });
   },
   undo: () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the ability to correct misrecognized words: select text in the transcript and click the new **Correct** button in the floating toolbar. A Descript-style popover opens, prefilled with the selected text; edit it and press Enter (or click Correct) to apply. Escape, the X button, or clicking away cancels. (No "Correct all", per request.)

[Correct popover prefilled with the selected words](https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4/artifacts?path=%2Ftmp%2Fe2e%2Fshots%2Fc1-popover.png)

## Behavior

- The new `correctWords` store action replaces the selected contiguous run of words. The corrected text can have a **different word count** — the original time span is redistributed across the new words in proportion to their character length, so timeline sync, playback highlighting, cutting, and export all keep working on corrected words.
- The new words inherit the speaker of the first selected word, and remain cut only if the entire selection was already cut (correcting otherwise implies you want the words).
- Corrections participate in undo/redo (⌘Z / ⇧⌘Z).
- While the popover is open, the selection highlight stays frozen on the affected words.

## Testing

Verified end-to-end in headless Chromium against a production build:

- Selecting the misrecognized "bag sentence" prefills the popover with exactly that text
- Correcting it to "bad, bad sentence" (2 → 3 words) updates the transcript; total word count 39 → 40
- ⌘Z restores the original text, ⇧⌘Z re-applies the correction
- The corrected words can then be selected and cut normally (new word ids work with the existing edit actions)
- `npm run lint` and `npm run build` pass (also removed an unused import in TopBar that was tripping lint)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

