### PR TITLE
Add one-click filler word removal

### DIFF
--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Eye, EyeOff, Pencil, RotateCcw, Scissors, X } from "lucide-react";
+import { Eye, EyeOff, Pencil, RotateCcw, Scissors, WandSparkles, X } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
+import { findFillerWordIds } from "@/lib/fillers";
 import type { SpeakerTurn, Word } from "@/lib/types";
 
 export const SPEAKER_COLORS = [
@@ -110,6 +111,11 @@ export default function TranscriptPanel() {
   }, [words]);
 
   const deletedCount = useMemo(() => words.filter((w) => w.deleted).length, [words]);
+  const fillerIds = useMemo(() => findFillerWordIds(words), [words]);
+
+  const removeFillers = useCallback(() => {
+    deleteWords(fillerIds);
+  }, [deleteWords, fillerIds]);
 
   const seekToWord = useCallback((word: Word) => {
     const { videoEl, setCurrentTime } = useEditorStore.getState();
@@ -281,6 +287,16 @@ export default function TranscriptPanel() {
             <span className="rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-500">
               {deletedCount} word{deletedCount === 1 ? "" : "s"} cut
             </span>
+          )}
+          {status === "ready" && fillerIds.length > 0 && (
+            <button
+              onClick={removeFillers}
+              title='Cut filler words ("um", "uh", …) from the video'
+              className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100"
+            >
+              <WandSparkles size={14} />
+              Remove fillers ({fillerIds.length})
+            </button>
           )}
           <button
             onClick={toggleShowDeleted}

--- a/lib/fillers.ts
+++ b/lib/fillers.ts
@@ -1,0 +1,44 @@
+import type { Word } from "./types";
+
+/**
+ * Filler sounds that carry no meaning and can safely be cut. Deliberately
+ * conservative: ambiguous words like "like", "so" or "right" are excluded
+ * because they are usually legitimate.
+ */
+const FILLER_WORDS = new Set([
+  "um",
+  "umm",
+  "ummm",
+  "uh",
+  "uhh",
+  "uhm",
+  "erm",
+  "er",
+  "err",
+  "ah",
+  "ahh",
+  "eh",
+  "ehm",
+  "hm",
+  "hmm",
+  "hmmm",
+  "mm",
+  "mmm",
+  "mhm",
+  "mm-hmm",
+  "uh-huh",
+]);
+
+/** Normalize a transcript token for matching: lowercase, strip punctuation. */
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}-]+$/gu, "");
+}
+
+export function isFillerWord(text: string): boolean {
+  return FILLER_WORDS.has(normalize(text));
+}
+
+/** Ids of all not-yet-deleted filler words in the transcript. */
+export function findFillerWordIds(words: Word[]): number[] {
+  return words.filter((w) => !w.deleted && isFillerWord(w.text)).map((w) => w.id);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Remove fillers (N)** button to the transcript header that cuts every detected filler word ("um", "uh", "erm", "hmm", "mm-hmm", …) from the video in one click.

[Remove fillers button in the transcript header](https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4/artifacts?path=%2Ftmp%2Fe2e%2Fshots%2Ff1-button.png)

## Behavior

- Detection lives in `lib/fillers.ts`: a conservative list of meaningless filler sounds, matched case-insensitively with surrounding punctuation stripped (so "Um," and "Uh-huh?" match). Ambiguous words that are often legitimate — "like", "so", "right", "you know" — are deliberately excluded to avoid mangling sentences.
- The button shows the live count of uncut fillers, only appears when there are any, and disappears once they're all removed.
- Removal reuses the existing `deleteWords` action, so filler cuts behave exactly like manual cuts: strikethrough in the transcript, red regions on the timeline, playback skipping, word-accurate export, and full undo/redo (individual fillers can also be restored by selecting them).

## Testing

Verified end-to-end in headless Chromium with a generated test video containing spoken fillers: the surviving "Um," in the transcript was detected ("Remove fillers (1)"), clicking cut exactly that word, the button disappeared, and ⌘Z restored it. Detection logic unit-checked against punctuated/uppercase variants and near-miss words ("summer", "a", "like" are not matched). `npm run lint` and `npm run build` pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

