### PR TITLE
Add Verbatim transcription mode to keep filler words

### DIFF
--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useRef, useState } from "react";
 import { Clapperboard, Loader2, Lock, Scissors, ShieldAlert, Type, Upload } from "lucide-react";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
+import { useEditorStore } from "@/lib/store";
+import { MODELS, type ModelChoice } from "@/lib/models";
 
 export default function UploadScreen({ onFile }: { onFile: (file: File) => void }) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -12,6 +14,8 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
   // would fail immediately and lose the file to that reload.
   const isolation = useCrossOriginIsolated();
   const ready = isolation === "ready";
+  const model = useEditorStore((s) => s.model);
+  const setModel = useEditorStore((s) => s.setModel);
 
   const handleFiles = useCallback(
     (files: FileList | null) => {
@@ -105,7 +109,39 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
           />
         </div>
 
-        <div className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="mt-6">
+          <p className="mb-2 text-xs font-semibold tracking-wider text-zinc-400 uppercase">
+            Transcription model
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {(Object.keys(MODELS) as ModelChoice[]).map((key) => {
+              const m = MODELS[key];
+              const selected = model === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setModel(key)}
+                  className={`rounded-xl border p-4 text-left transition ${
+                    selected
+                      ? "border-zinc-800 bg-white ring-1 ring-zinc-800"
+                      : "border-zinc-200 bg-white/70 hover:border-zinc-400"
+                  }`}
+                >
+                  <span className="flex items-center justify-between">
+                    <span className="text-[13px] font-semibold text-zinc-800">{m.label}</span>
+                    <span className="text-xs text-zinc-400">{m.size}</span>
+                  </span>
+                  <span className="mt-0.5 block text-xs leading-relaxed text-zinc-500">
+                    {m.description}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
           {[
             { icon: Type, title: "Transcribe", text: "Per-word timing and speaker labels." },
             { icon: Scissors, title: "Edit", text: "Select words and hit delete to edit." },

--- a/hooks/useTranscriber.ts
+++ b/hooks/useTranscriber.ts
@@ -52,7 +52,10 @@ export function useTranscriber() {
 
     // Transfer a copy so the original stays available for the waveform.
     const copy = audio.slice();
-    workerRef.current.postMessage({ audio: copy, duration }, [copy.buffer]);
+    workerRef.current.postMessage(
+      { audio: copy, duration, model: store.model },
+      [copy.buffer]
+    );
   }, []);
 
   return { transcribe };

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,0 +1,57 @@
+/** Transcription model choices offered on the upload screen. */
+export type ModelChoice = "fast" | "verbatim";
+
+type DType = "fp32" | "fp16" | "q8" | "int8" | "uint8" | "q4" | "q4f16" | "bnb4";
+
+export interface ModelInfo {
+  /** Hugging Face model id (ONNX export compatible with transformers.js). */
+  id: string;
+  label: string;
+  description: string;
+  /** Approximate download size shown in the UI. */
+  size: string;
+  /** dtype configuration per device. */
+  dtype: {
+    webgpu: Record<string, DType>;
+    wasm: Record<string, DType>;
+  };
+  /**
+   * Whisper is trained to produce "clean" transcripts and usually drops
+   * disfluencies. Conditioning the decoder on a prompt that itself contains
+   * fillers biases it toward verbatim output. The prompt is injected as
+   * `<|startofprev|> …prompt… <|startoftranscript|>` decoder tokens.
+   *
+   * (A dedicated verbatim model — CrisperWhisper — was evaluated, but its
+   * only browser-runnable ONNX export lacks the cross-attention outputs
+   * required for word-level timestamps, which this editor depends on.)
+   */
+  verbatimPrompt?: string;
+}
+
+const WHISPER_BASE = "onnx-community/whisper-base_timestamped";
+const WHISPER_BASE_DTYPE = {
+  // q4 decoder: q8 fails session creation on onnxruntime-web 1.26
+  // (Missing required scale … MatMulNBits).
+  webgpu: { encoder_model: "fp32", decoder_model_merged: "q4" },
+  wasm: { encoder_model: "fp32", decoder_model_merged: "q4" },
+} satisfies ModelInfo["dtype"];
+
+export const MODELS: Record<ModelChoice, ModelInfo> = {
+  fast: {
+    id: WHISPER_BASE,
+    label: "Standard",
+    description: "Fast on any device. May clean up filler words (\u201cum\u201d, \u201cuh\u201d).",
+    size: "~80 MB",
+    dtype: WHISPER_BASE_DTYPE,
+  },
+  verbatim: {
+    id: WHISPER_BASE,
+    label: "Verbatim",
+    description:
+      "Tries to keep filler words (\u201cum\u201d, \u201cuh\u201d) in the transcript so you can cut them. Same speed and size.",
+    size: "~80 MB",
+    dtype: WHISPER_BASE_DTYPE,
+    verbatimPrompt:
+      "Umm, let me think like, hmm... Okay, here's what I'm, like, thinking, um, yeah.",
+  },
+};

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import type { EditorStatus, ProgressInfo, Word } from "./types";
+import type { ModelChoice } from "./models";
 
 interface EditorState {
   // Media
@@ -10,6 +11,8 @@ interface EditorState {
   duration: number;
   /** Mono 16 kHz PCM of the video's audio track (used for waveform + ASR). */
   audio: Float32Array | null;
+  /** Transcription model selected on the upload screen. */
+  model: ModelChoice;
 
   // Pipeline status
   status: EditorStatus;
@@ -35,6 +38,7 @@ interface EditorState {
 
   // Actions
   loadVideo: (file: File) => void;
+  setModel: (m: ModelChoice) => void;
   setDuration: (d: number) => void;
   setAudio: (a: Float32Array) => void;
   setStatus: (s: EditorStatus) => void;
@@ -62,6 +66,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   videoUrl: null,
   duration: 0,
   audio: null,
+  model: "fast",
 
   status: "idle",
   progress: { message: "", value: null },
@@ -97,6 +102,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       exportUrl: null,
     });
   },
+  setModel: (model) => set({ model }),
   setDuration: (duration) => set({ duration }),
   setAudio: (audio) => set({ audio }),
   setStatus: (status) => set({ status }),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,5 +51,7 @@ export interface WorkerRequest {
   audio: Float32Array;
   /** Total media duration in seconds (used for progress estimation). */
   duration: number;
+  /** Which transcription model to use (see lib/models.ts). */
+  model: import("./models").ModelChoice;
   language?: string;
 }

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -1,8 +1,8 @@
 /**
  * Transcription worker: runs entirely in the browser.
  *
- * 1. Whisper (onnx-community/whisper-base_timestamped) produces a transcript
- *    with per-word timestamps.
+ * 1. A Whisper-family model (see lib/models.ts) produces a transcript with
+ *    per-word timestamps.
  * 2. Pyannote segmentation 3.0 produces speaker segments, which are used to
  *    assign a speaker to each word.
  *
@@ -19,6 +19,7 @@ import {
   type AutomaticSpeechRecognitionPipeline,
 } from "@huggingface/transformers";
 import type { Word, WorkerRequest, WorkerResponse } from "@/lib/types";
+import { MODELS, type ModelChoice } from "@/lib/models";
 
 env.allowLocalModels = false;
 // Serve onnxruntime-web WASM from our own origin (offline friendly).
@@ -26,7 +27,6 @@ if (env.backends?.onnx?.wasm) {
   env.backends.onnx.wasm.wasmPaths = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/vendor/ort/`;
 }
 
-const ASR_MODEL = "onnx-community/whisper-base_timestamped";
 const DIARIZATION_MODEL = "onnx-community/pyannote-segmentation-3.0";
 
 const post = (msg: WorkerResponse, transfer: Transferable[] = []) =>
@@ -87,31 +87,75 @@ async function pickDevice(): Promise<"webgpu" | "wasm"> {
   return "wasm";
 }
 
-let asrPromise: Promise<AutomaticSpeechRecognitionPipeline> | null = null;
-async function getAsr() {
-  if (!asrPromise) {
+// Keyed by model id: choices that share the same underlying model (e.g.
+// "fast" and "verbatim", which differ only in prompting) share one pipeline.
+const asrPromises = new Map<string, Promise<AutomaticSpeechRecognitionPipeline>>();
+async function getAsr(choice: ModelChoice) {
+  const { id, dtype } = MODELS[choice];
+  let promise = asrPromises.get(id);
+  if (!promise) {
     const device = await pickDevice();
-    const dtype = { encoder_model: "fp32", decoder_model_merged: "q4" } as const;
-    const label = (await isModelCached(ASR_MODEL))
+    const label = (await isModelCached(id))
       ? "Loading speech model from cache…"
       : "Downloading speech model…";
-    asrPromise = pipeline("automatic-speech-recognition", ASR_MODEL, {
-      dtype,
+    promise = pipeline("automatic-speech-recognition", id, {
+      dtype: dtype[device],
       device,
       progress_callback: makeDownloadTracker(label),
     }).catch((err) => {
       // WebGPU can fail on some drivers; retry once on plain WASM.
       if (device === "webgpu") {
-        return pipeline("automatic-speech-recognition", ASR_MODEL, {
-          dtype,
+        return pipeline("automatic-speech-recognition", id, {
+          dtype: dtype.wasm,
           device: "wasm",
           progress_callback: makeDownloadTracker(label),
         });
       }
       throw err;
     }) as Promise<AutomaticSpeechRecognitionPipeline>;
+    asrPromises.set(id, promise);
+    promise.catch(() => asrPromises.delete(id));
   }
-  return asrPromise;
+  return promise;
+}
+
+/**
+ * Build decoder input tokens implementing Whisper's "initial prompt"
+ * conditioning: `<|startofprev|> …prompt… <|startoftranscript|> <|lang|>
+ * <|transcribe|>`. transformers.js documents `prompt_ids` but does not
+ * implement it, so the tokens are constructed manually and passed as
+ * `decoder_input_ids` (which `generate` honors for every chunk). Returns
+ * null if any required token cannot be resolved.
+ */
+function buildPromptedDecoderIds(
+  transcriber: AutomaticSpeechRecognitionPipeline,
+  prompt: string,
+  language: string
+): number[] | null {
+  try {
+    // Tokenizer/config internals are untyped in transformers.js.
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const tokenizer = transcriber.tokenizer as any;
+    const genCfg = (transcriber.model as any).generation_config;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    const startOfPrev = tokenizer.encode("<|startofprev|>", { add_special_tokens: false });
+    const promptIds = tokenizer.encode(" " + prompt.trim(), { add_special_tokens: false });
+    const startId = genCfg?.decoder_start_token_id;
+    const langId = genCfg?.lang_to_id?.[`<|${language}|>`];
+    const taskId = genCfg?.task_to_id?.["transcribe"];
+    if (
+      startOfPrev?.length !== 1 ||
+      !promptIds?.length ||
+      startId == null ||
+      langId == null ||
+      taskId == null
+    ) {
+      return null;
+    }
+    return [startOfPrev[0], ...promptIds, startId, langId, taskId];
+  } catch {
+    return null;
+  }
 }
 
 interface DiarizationSegment {
@@ -197,9 +241,18 @@ function assignSpeakers(words: Word[], segments: DiarizationSegment[]) {
 }
 
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
-  const { audio, duration, language } = event.data;
+  const { audio, duration, model, language } = event.data;
   try {
-    const transcriber = await getAsr();
+    const choice = model ?? "fast";
+    const transcriber = await getAsr(choice);
+
+    const { verbatimPrompt } = MODELS[choice];
+    const promptedIds = verbatimPrompt
+      ? buildPromptedDecoderIds(transcriber, verbatimPrompt, language ?? "en")
+      : null;
+    if (verbatimPrompt && !promptedIds) {
+      console.warn("Could not build verbatim prompt tokens; using default decoding.");
+    }
     // Warm up the speaker model in parallel with transcription (errors are
     // handled when it is awaited later; this avoids an unhandled rejection).
     getDiarizer().catch(() => {});
@@ -243,7 +296,8 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       chunk_length_s: chunkLength,
       stride_length_s: stride,
       return_timestamps: "word",
-      language,
+      // decoder_input_ids overrides language/task tokens when prompting.
+      ...(promptedIds ? { decoder_input_ids: promptedIds } : { language }),
       streamer,
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Whisper is trained to emit "clean" transcripts and usually drops disfluencies ("um", "uh", …), which is why **Remove fillers** often has little to act on. This PR adds a **Verbatim** transcription mode that biases Whisper toward keeping them.

Rebased onto current `main` (including the merged Remove fillers work) so the diff is a clean 6-file change.

**Why not CrisperWhisper?** [`unsloth/CrisperWhisper`](https://huggingface.co/unsloth/CrisperWhisper) / [`nyralabs/CrisperWhisper`](https://huggingface.co/nyralabs/CrisperWhisper) is the right model for verbatim speech, and there is a browser ONNX export at [`onnx-community/CrisperWhisper-ONNX`](https://huggingface.co/onnx-community/CrisperWhisper-ONNX) (~1 GB q4). That export was compiled **without** `output_attentions=True`, so transformers.js cannot produce word-level timestamps (`Model outputs must contain cross attentions to extract timestamps`). Without those, cut/timeline/export don't work, so it isn't usable here today.

## Approach

- Upload screen gains a **Standard / Verbatim** picker (`lib/models.ts`).
- Both modes use the same `onnx-community/whisper-base_timestamped` weights (shared cache, same ~80 MB download and speed).
- Verbatim mode builds Whisper's documented initial-prompt prefix and passes it as `decoder_input_ids`:
  `<|startofprev|> Umm, let me think like, hmm… <|startoftranscript|> <|en|> <|transcribe|>`
  Conditioning on a filler-rich prompt biases the decoder toward emitting fillers instead of cleaning them up. (transformers.js documents `prompt_ids` but doesn't implement it, so the tokens are constructed manually.)

## Files changed

- `lib/models.ts` — Standard / Verbatim model definitions + verbatim prompt
- `components/UploadScreen.tsx` — model picker UI
- `lib/store.ts` / `lib/types.ts` / `hooks/useTranscriber.ts` — pass selected model through
- `workers/transcription.worker.ts` — prompt-token construction + per-model pipeline cache

## Testing

Headless Chromium against a production build, same espeak filler video ("Um, so today… uh… Hmm… um…"):

| Mode | Words | Fillers kept |
| --- | --- | --- |
| Standard | 22 | `Um,` (1) |
| Verbatim | 24 | `uh,` `Um,` `um,` (3) |

Verbatim transcript: *"So today we are going to talk about, uh, editing videos with text. Um, I think, um, this is going to be really useful."*

`npm run lint` and `npm run build` pass.

## Follow-ups

Once someone re-exports CrisperWhisper ONNX with cross-attentions (or a smaller verbatim model with timestamps lands), we can swap Verbatim over to it for true verbatim accuracy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

