### PR TITLE
Add support for editing audio files

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -12,7 +12,7 @@ browser, with no server, no auth, and no API calls.
 │ Next.js (App Router, client-only editor)                           │
 │                                                                    │
 │  ┌───────────────┐  ┌────────────────┐  ┌───────────────────────┐  │
-│  │ TranscriptPanel│  │ VideoPreview  │  │ Timeline (canvas)     │  │
+│  │ TranscriptPanel│  │ MediaPreview  │  │ Timeline (canvas)     │  │
 │  │ words / cuts   │  │ skip playback │  │ waveform + playhead   │  │
 │  └───────┬───────┘  └───────┬────────┘  └──────────┬────────────┘  │
 │          └───────────── zustand store ─────────────┘               │

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 # Rescript
 
-**Edit videos like you edit text — fully offline, in your browser.**
+**Edit video and audio like you edit text — fully offline, in your browser.**
 
 **✨ Try it now: [wassgha.github.io/rescript](https://wassgha.github.io/rescript/)**
 
 [![Rescript Demo](./screenshots/rescript.png)](https://wassgha.github.io/rescript/)
 
-Rescript is an open-source, transcript-based video editor. Drop in a video and
-it is transcribed locally with per-word timestamps and speaker labels. Delete
-words in the transcript and the corresponding clip is cut from the video.
-Export the final cut to MP4 — without your video ever leaving your device.
+Rescript is an open-source, transcript-based media editor. Drop in a video or
+audio file and it is transcribed locally with per-word timestamps and speaker
+labels. Delete words in the transcript and the corresponding clip is cut from
+the media. Export the final cut — without your file ever leaving your device.
 
 - 🔒 **Private by design** — no server, no auth, no uploads; all media processing happens on-device
 - 📝 **Word-level editing** — select words, press ⌫, the cut follows the text
@@ -21,7 +21,8 @@ Export the final cut to MP4 — without your video ever leaving your device.
 - 🗣️ **Speaker diarization** — the transcript is grouped by speaker
 - 🎬 **Timeline** — waveform, word labels, cut regions, playhead, zoom
 - ⚡ **Live preview** — playback skips your cuts in real time
-- 📦 **In-browser export** — frame-accurate MP4 render with ffmpeg.wasm
+- 📦 **In-browser export** — frame-accurate MP4 (video) or M4A (audio) with ffmpeg.wasm
+- 🎧 **Audio files** — edit podcasts, voice notes, and interviews the same way as video
 
 ## Stack
 

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -33,7 +33,7 @@ export default function Editor() {
         transcribe(audio, audio.length / 16000);
       } catch (err) {
         console.error("Processing pipeline failed:", err);
-        s.setError(err instanceof Error ? err.message : "Failed to process this video.");
+        s.setError(err instanceof Error ? err.message : "Failed to process this file.");
       }
     })();
   }, [videoFile, transcribe]);

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -7,7 +7,7 @@ import { useTranscriber } from "@/hooks/useTranscriber";
 import TopBar from "./TopBar";
 import UploadScreen from "./UploadScreen";
 import TranscriptPanel from "./TranscriptPanel";
-import VideoPreview from "./VideoPreview";
+import MediaPreview from "./MediaPreview";
 import Timeline from "./Timeline";
 import ExportDialog from "./ExportDialog";
 
@@ -69,7 +69,7 @@ export default function Editor() {
           <div className="flex min-h-0 flex-1">
             <TranscriptPanel />
             <div className="flex w-[44%] min-w-[320px] shrink-0 flex-col border-l border-zinc-200">
-              <VideoPreview />
+              <MediaPreview />
             </div>
             {/* <SideRail /> — hidden until the tools it exposes are functional */}
           </div>

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -4,12 +4,13 @@ import { useCallback, useMemo, useState } from "react";
 import { Download, X } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import { formatTime, getCutRanges, getEditedDuration, getKeepRanges } from "@/lib/edits";
-import { exportVideo } from "@/lib/ffmpeg";
+import { exportAudio, exportVideo } from "@/lib/ffmpeg";
 
 export default function ExportDialog() {
   const open = useEditorStore((s) => s.exportOpen);
   const setOpen = useEditorStore((s) => s.setExportOpen);
   const videoFile = useEditorStore((s) => s.videoFile);
+  const mediaKind = useEditorStore((s) => s.mediaKind);
   const words = useEditorStore((s) => s.words);
   const duration = useEditorStore((s) => s.duration);
   const status = useEditorStore((s) => s.status);
@@ -23,10 +24,13 @@ export default function ExportDialog() {
   const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
   const editedDuration = useMemo(() => getEditedDuration(cuts, duration), [cuts, duration]);
   const exporting = status === "exporting";
+  const isAudio = mediaKind === "audio";
+  const ext = isAudio ? "m4a" : "mp4";
+  const formatLabel = isAudio ? "M4A" : "MP4";
 
   const fileName = videoFile
-    ? videoFile.name.replace(/\.[^.]+$/, "") + ".edited.mp4"
-    : "edited.mp4";
+    ? videoFile.name.replace(/\.[^.]+$/, "") + `.edited.${ext}`
+    : `edited.${ext}`;
 
   const start = useCallback(async () => {
     if (!videoFile) return;
@@ -35,7 +39,9 @@ export default function ExportDialog() {
     setStatus("exporting");
     try {
       const keeps = getKeepRanges(cuts, duration);
-      const blob = await exportVideo(videoFile, keeps, editedDuration, setProgress);
+      const blob = isAudio
+        ? await exportAudio(videoFile, keeps, editedDuration, setProgress)
+        : await exportVideo(videoFile, keeps, editedDuration, setProgress);
       const prev = useEditorStore.getState().exportUrl;
       if (prev) URL.revokeObjectURL(prev);
       setExportUrl(URL.createObjectURL(blob));
@@ -44,7 +50,7 @@ export default function ExportDialog() {
     } finally {
       setStatus("ready");
     }
-  }, [videoFile, cuts, duration, editedDuration, setStatus, setExportUrl]);
+  }, [videoFile, isAudio, cuts, duration, editedDuration, setStatus, setExportUrl]);
 
   if (!open) return null;
 
@@ -58,7 +64,9 @@ export default function ExportDialog() {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-zinc-900">Export video</h2>
+          <h2 className="text-lg font-semibold text-zinc-900">
+            Export {isAudio ? "audio" : "video"}
+          </h2>
           <button
             onClick={() => setOpen(false)}
             disabled={exporting}
@@ -106,7 +114,7 @@ export default function ExportDialog() {
               />
             </div>
             <p className="mt-3 text-xs text-zinc-400">
-              Re-encoding with ffmpeg.wasm — longer videos take a while.
+              Re-encoding with ffmpeg.wasm — longer files take a while.
             </p>
           </div>
         ) : exportUrl ? (
@@ -132,7 +140,7 @@ export default function ExportDialog() {
             className="flex h-10 w-full items-center justify-center gap-2 rounded-xl bg-zinc-900 text-sm font-medium text-white transition hover:bg-zinc-700"
           >
             <Download size={15} />
-            Export MP4
+            Export {formatLabel}
           </button>
         )}
       </div>

--- a/components/MediaPreview.tsx
+++ b/components/MediaPreview.tsx
@@ -11,7 +11,7 @@ import {
   originalToEdited,
 } from "@/lib/edits";
 
-export default function VideoPreview() {
+export default function MediaPreview() {
   const mediaUrl = useEditorStore((s) => s.mediaUrl);
   const videoFile = useEditorStore((s) => s.videoFile);
   const mediaKind = useEditorStore((s) => s.mediaKind);

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, Home, Redo2, Undo2 } from "lucide-react";
+import { Download, Redo2, Undo2 } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import Image from "next/image";
 import logo from "@/assets/logo.png";

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { Clapperboard, Loader2, Lock, Scissors, ShieldAlert, Type, Upload } from "lucide-react";
 import logo from "@/assets/logo.png";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
+import { detectMediaKind, MEDIA_ACCEPT } from "@/lib/media";
 
 export default function UploadScreen({ onFile }: { onFile: (file: File) => void }) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -20,8 +21,8 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
       if (!ready) return;
       const file = files?.[0];
       if (!file) return;
-      if (!file.type.startsWith("video/") && !/\.(mp4|webm|mov|mkv|m4v)$/i.test(file.name)) {
-        alert("Please choose a video file.");
+      if (!detectMediaKind(file)) {
+        alert("Please choose a video or audio file.");
         return;
       }
       onFile(file);
@@ -95,10 +96,11 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
           ) : ready ? (
             <>
               <p className="text-[15px] font-medium text-zinc-800">
-                Drop a video here, or <span className="text-neutral-600">browse</span>
+                Drop a video or audio file here, or{" "}
+                <span className="text-neutral-600">browse</span>
               </p>
               <p className="mt-1 text-[13px] text-zinc-400">
-                MP4, WebM or MOV with an audio track
+                MP4, WebM, MOV, MP3, WAV, M4A, …
               </p>
             </>
           ) : (
@@ -112,7 +114,7 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
           <input
             ref={inputRef}
             type="file"
-            accept="video/*"
+            accept={MEDIA_ACCEPT}
             className="hidden"
             onChange={(e) => handleFiles(e.target.files)}
           />
@@ -122,7 +124,7 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
           {[
             { icon: Type, title: "Transcribe", text: "Per-word timing and speaker labels." },
             { icon: Scissors, title: "Edit", text: "Select words and hit delete to edit." },
-            { icon: Clapperboard, title: "Export", text: "Render the final cut to MP4." },
+            { icon: Clapperboard, title: "Export", text: "Render the final cut to MP4 or M4A." },
           ].map(({ icon: Icon, title, text }) => (
             <div key={title} className="rounded-xl border border-zinc-200 bg-white/70 p-4">
               <Icon size={16} className="mb-2 text-neutral-500" />
@@ -134,7 +136,7 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
 
         <p className="mt-6 flex items-center justify-center gap-1.5 text-center text-xs text-zinc-400">
           <Lock size={12} />
-          No uploads, no accounts — your video never leaves this device.
+          No uploads, no accounts — your media never leaves this device.
         </p>
       </div>
     </div>

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/lib/edits";
 
 export default function VideoPreview() {
-  const videoUrl = useEditorStore((s) => s.videoUrl);
+  const mediaUrl = useEditorStore((s) => s.mediaUrl);
   const videoFile = useEditorStore((s) => s.videoFile);
   const mediaKind = useEditorStore((s) => s.mediaKind);
   const words = useEditorStore((s) => s.words);
@@ -98,7 +98,7 @@ export default function VideoPreview() {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-zinc-50/70 p-4">
       <div className="flex min-h-0 flex-1 items-center justify-center">
-        {videoUrl && isAudio && (
+        {mediaUrl && isAudio && (
           <>
             <button
               type="button"
@@ -115,7 +115,7 @@ export default function VideoPreview() {
             </button>
             <audio
               ref={refCb}
-              src={videoUrl}
+              src={mediaUrl}
               preload="metadata"
               onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
               onPlay={() => setPlaying(true)}
@@ -124,10 +124,10 @@ export default function VideoPreview() {
             />
           </>
         )}
-        {videoUrl && !isAudio && (
+        {mediaUrl && !isAudio && (
           <video
             ref={refCb}
-            src={videoUrl}
+            src={mediaUrl}
             playsInline
             onClick={togglePlay}
             onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
+import { AudioLines, Pause, Play, SkipBack, SkipForward } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import {
   cutRangeAt,
@@ -13,6 +13,8 @@ import {
 
 export default function VideoPreview() {
   const videoUrl = useEditorStore((s) => s.videoUrl);
+  const videoFile = useEditorStore((s) => s.videoFile);
+  const mediaKind = useEditorStore((s) => s.mediaKind);
   const words = useEditorStore((s) => s.words);
   const duration = useEditorStore((s) => s.duration);
   const playing = useEditorStore((s) => s.playing);
@@ -22,7 +24,8 @@ export default function VideoPreview() {
   const setPlaying = useEditorStore((s) => s.setPlaying);
   const setCurrentTime = useEditorStore((s) => s.setCurrentTime);
 
-  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const mediaRef = useRef<HTMLMediaElement | null>(null);
+  const isAudio = mediaKind === "audio";
   const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
   const cutsRef = useRef(cuts);
   useEffect(() => {
@@ -35,8 +38,8 @@ export default function VideoPreview() {
   );
 
   const refCb = useCallback(
-    (el: HTMLVideoElement | null) => {
-      videoRef.current = el;
+    (el: HTMLMediaElement | null) => {
+      mediaRef.current = el;
       setVideoEl(el);
     },
     [setVideoEl]
@@ -46,19 +49,19 @@ export default function VideoPreview() {
   useEffect(() => {
     let raf = 0;
     const tick = () => {
-      const video = videoRef.current;
-      if (video) {
-        let t = video.currentTime;
-        if (!video.paused) {
+      const media = mediaRef.current;
+      if (media) {
+        let t = media.currentTime;
+        if (!media.paused) {
           const cut = cutRangeAt(t, cutsRef.current);
           if (cut) {
             const target = cut.end + 0.001;
-            if (target >= video.duration - 0.05) {
-              video.pause();
-              video.currentTime = cut.start;
+            if (target >= media.duration - 0.05) {
+              media.pause();
+              media.currentTime = cut.start;
               t = cut.start;
             } else {
-              video.currentTime = target;
+              media.currentTime = target;
               t = target;
             }
           }
@@ -73,29 +76,55 @@ export default function VideoPreview() {
   }, [setCurrentTime]);
 
   const togglePlay = useCallback(() => {
-    const video = videoRef.current;
-    if (!video) return;
-    if (video.paused) {
+    const media = mediaRef.current;
+    if (!media) return;
+    if (media.paused) {
       // If we're parked inside a cut (or at the end), jump to kept content.
-      const cut = cutRangeAt(video.currentTime, cutsRef.current);
-      if (cut) video.currentTime = cut.end + 0.001;
-      if (video.currentTime >= video.duration - 0.05) video.currentTime = 0;
-      void video.play();
+      const cut = cutRangeAt(media.currentTime, cutsRef.current);
+      if (cut) media.currentTime = cut.end + 0.001;
+      if (media.currentTime >= media.duration - 0.05) media.currentTime = 0;
+      void media.play();
     } else {
-      video.pause();
+      media.pause();
     }
   }, []);
 
   const skip = useCallback((delta: number) => {
-    const video = videoRef.current;
-    if (!video) return;
-    video.currentTime = Math.min(Math.max(0, video.currentTime + delta), video.duration);
+    const media = mediaRef.current;
+    if (!media) return;
+    media.currentTime = Math.min(Math.max(0, media.currentTime + delta), media.duration);
   }, []);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-zinc-50/70 p-4">
       <div className="flex min-h-0 flex-1 items-center justify-center">
-        {videoUrl && (
+        {videoUrl && isAudio && (
+          <>
+            <button
+              type="button"
+              onClick={togglePlay}
+              className="flex w-full max-w-md cursor-pointer flex-col items-center gap-3 rounded-2xl border border-zinc-200 bg-white px-8 py-14 text-center shadow-sm transition hover:border-zinc-300"
+            >
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-zinc-900 text-white">
+                <AudioLines size={24} />
+              </div>
+              <p className="max-w-full truncate text-sm font-medium text-zinc-800">
+                {videoFile?.name ?? "Audio"}
+              </p>
+              <p className="text-xs text-zinc-400">Audio · click to play</p>
+            </button>
+            <audio
+              ref={refCb}
+              src={videoUrl}
+              preload="metadata"
+              onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
+              onPlay={() => setPlaying(true)}
+              onPause={() => setPlaying(false)}
+              className="hidden"
+            />
+          </>
+        )}
+        {videoUrl && !isAudio && (
           <video
             ref={refCb}
             src={videoUrl}

--- a/lib/ffmpeg.ts
+++ b/lib/ffmpeg.ts
@@ -58,6 +58,7 @@ async function ensureInput(ffmpeg: FFmpeg, file: File): Promise<string> {
 /**
  * Extract the audio track as mono 16 kHz float PCM — the exact format
  * Whisper expects, and what we render the timeline waveform from.
+ * Works for both video and audio-only files.
  */
 export async function extractAudio(file: File): Promise<Float32Array> {
   const ffmpeg = await getFFmpeg();
@@ -72,12 +73,12 @@ export async function extractAudio(file: File): Promise<Float32Array> {
     "-y", out,
   ]);
   if (code !== 0) {
-    throw new Error("Could not extract audio from this file. Does it have an audio track?");
+    throw new Error("Could not extract audio from this file.");
   }
   const data = (await ffmpeg.readFile(out)) as Uint8Array;
   await ffmpeg.deleteFile(out);
   if (data.byteLength < 4) {
-    throw new Error("This video appears to have no audio track.");
+    throw new Error("This file appears to have no audio track.");
   }
   // Copy into a fresh buffer so byteOffset/alignment is clean.
   const buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
@@ -140,6 +141,60 @@ export async function exportVideo(
     await ffmpeg.deleteFile(out);
     const buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
     return new Blob([buf as ArrayBuffer], { type: "video/mp4" });
+  } finally {
+    ffmpeg.off("progress", progressHandler);
+  }
+}
+
+/**
+ * Render an edited audio-only file: keep only `keepRanges` and concatenate
+ * them into an M4A (AAC) container.
+ */
+export async function exportAudio(
+  file: File,
+  keepRanges: TimeRange[],
+  editedDuration: number,
+  onProgress: (ratio: number) => void
+): Promise<Blob> {
+  if (keepRanges.length === 0) {
+    throw new Error("Everything has been deleted — nothing to export.");
+  }
+  const ffmpeg = await getFFmpeg();
+  const input = await ensureInput(ffmpeg, file);
+  const out = "output.m4a";
+
+  const parts: string[] = [];
+  const labels: string[] = [];
+  keepRanges.forEach((r, i) => {
+    const s = r.start.toFixed(3);
+    const e = r.end.toFixed(3);
+    parts.push(`[0:a]atrim=start=${s}:end=${e},asetpts=PTS-STARTPTS[a${i}]`);
+    labels.push(`[a${i}]`);
+  });
+  const filter =
+    parts.join(";") +
+    `;${labels.join("")}concat=n=${keepRanges.length}:v=0:a=1[outa]`;
+
+  const progressHandler = ({ time }: { progress: number; time: number }) => {
+    const ratio = Math.min(1, time / 1e6 / Math.max(0.001, editedDuration));
+    onProgress(Math.max(0, ratio));
+  };
+  ffmpeg.on("progress", progressHandler);
+  try {
+    const code = await ffmpeg.exec([
+      "-i", input,
+      "-filter_complex", filter,
+      "-map", "[outa]",
+      "-c:a", "aac",
+      "-b:a", "192k",
+      "-movflags", "+faststart",
+      "-y", out,
+    ]);
+    if (code !== 0) throw new Error("Export failed while rendering the audio.");
+    const data = (await ffmpeg.readFile(out)) as Uint8Array;
+    await ffmpeg.deleteFile(out);
+    const buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+    return new Blob([buf as ArrayBuffer], { type: "audio/mp4" });
   } finally {
     ffmpeg.off("progress", progressHandler);
   }

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -1,0 +1,15 @@
+/** Supported media kinds for the editor. */
+export type MediaKind = "video" | "audio";
+
+const VIDEO_EXT = /\.(mp4|webm|mov|mkv|m4v)$/i;
+const AUDIO_EXT = /\.(mp3|wav|m4a|aac|ogg|flac|opus|wma)$/i;
+
+/** Classify a File as video, audio, or unsupported (null). */
+export function detectMediaKind(file: File): MediaKind | null {
+  if (file.type.startsWith("video/") || VIDEO_EXT.test(file.name)) return "video";
+  if (file.type.startsWith("audio/") || AUDIO_EXT.test(file.name)) return "audio";
+  return null;
+}
+
+export const MEDIA_ACCEPT =
+  "video/*,audio/*,.mp4,.webm,.mov,.mkv,.m4v,.mp3,.wav,.m4a,.aac,.ogg,.flac,.opus";

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -8,7 +8,7 @@ import { detectMediaKind, type MediaKind } from "./media";
 interface EditorState {
   // Media
   videoFile: File | null;
-  videoUrl: string | null;
+  mediaUrl: string | null;
   /** Whether the loaded file is video or audio-only. */
   mediaKind: MediaKind | null;
   duration: number;
@@ -66,7 +66,7 @@ interface EditorState {
 
 export const useEditorStore = create<EditorState>((set, get) => ({
   videoFile: null,
-  videoUrl: null,
+  mediaUrl: null,
   mediaKind: null,
   duration: 0,
   audio: null,
@@ -92,11 +92,11 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   loadVideo: (file) => {
     const kind = detectMediaKind(file);
     if (!kind) return;
-    const prev = get().videoUrl;
+    const prev = get().mediaUrl;
     if (prev) URL.revokeObjectURL(prev);
     set({
       videoFile: file,
-      videoUrl: URL.createObjectURL(file),
+      mediaUrl: URL.createObjectURL(file),
       mediaKind: kind,
       status: "preparing",
       progress: { message: "Loading media engine…", value: null },
@@ -212,12 +212,12 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   setExportOpen: (exportOpen) => set({ exportOpen }),
 
   reset: () => {
-    const { videoUrl, exportUrl } = get();
-    if (videoUrl) URL.revokeObjectURL(videoUrl);
+    const { mediaUrl, exportUrl } = get();
+    if (mediaUrl) URL.revokeObjectURL(mediaUrl);
     if (exportUrl) URL.revokeObjectURL(exportUrl);
     set({
       videoFile: null,
-      videoUrl: null,
+      mediaUrl: null,
       mediaKind: null,
       duration: 0,
       audio: null,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,13 +3,16 @@
 import { create } from "zustand";
 import type { EditorStatus, ProgressInfo, Word } from "./types";
 import type { ModelChoice } from "./models";
+import { detectMediaKind, type MediaKind } from "./media";
 
 interface EditorState {
   // Media
   videoFile: File | null;
   videoUrl: string | null;
+  /** Whether the loaded file is video or audio-only. */
+  mediaKind: MediaKind | null;
   duration: number;
-  /** Mono 16 kHz PCM of the video's audio track (used for waveform + ASR). */
+  /** Mono 16 kHz PCM of the media's audio track (used for waveform + ASR). */
   audio: Float32Array | null;
   /** Transcription model selected on the upload screen. */
   model: ModelChoice;
@@ -27,10 +30,10 @@ interface EditorState {
   past: Word[][];
   future: Word[][];
 
-  // Playback (mirrored from the <video> element for UI rendering)
+  // Playback (mirrored from the <video>/<audio> element for UI rendering)
   currentTime: number;
   playing: boolean;
-  videoEl: HTMLVideoElement | null;
+  videoEl: HTMLMediaElement | null;
 
   // Export
   exportUrl: string | null;
@@ -55,7 +58,7 @@ interface EditorState {
   toggleShowDeleted: () => void;
   setCurrentTime: (t: number) => void;
   setPlaying: (p: boolean) => void;
-  setVideoEl: (el: HTMLVideoElement | null) => void;
+  setVideoEl: (el: HTMLMediaElement | null) => void;
   setExportUrl: (url: string | null) => void;
   setExportOpen: (open: boolean) => void;
   reset: () => void;
@@ -64,6 +67,7 @@ interface EditorState {
 export const useEditorStore = create<EditorState>((set, get) => ({
   videoFile: null,
   videoUrl: null,
+  mediaKind: null,
   duration: 0,
   audio: null,
   model: "verbatim",
@@ -86,11 +90,14 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   exportOpen: false,
 
   loadVideo: (file) => {
+    const kind = detectMediaKind(file);
+    if (!kind) return;
     const prev = get().videoUrl;
     if (prev) URL.revokeObjectURL(prev);
     set({
       videoFile: file,
       videoUrl: URL.createObjectURL(file),
+      mediaKind: kind,
       status: "preparing",
       progress: { message: "Loading media engine…", value: null },
       words: [],
@@ -211,6 +218,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     set({
       videoFile: null,
       videoUrl: null,
+      mediaKind: null,
       duration: 0,
       audio: null,
       status: "idle",


### PR DESCRIPTION
Closes #11 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds full support for editing **audio files** (podcasts, voice notes, interviews) the same way as video: upload → transcribe → cut by deleting words → export.

[Audio editor with transcript and audio preview card](https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4/artifacts?path=%2Ftmp%2Fe2e%2Fshots%2Fa2-editor.png)

## Changes

- **Upload** — accepts `audio/*` plus mp3/wav/m4a/aac/ogg/flac/opus (alongside existing video formats). Shared `detectMediaKind` helper in `lib/media.ts`.
- **Preview** — `VideoPreview` renamed to `MediaPreview`; audio projects show a clickable audio card + hidden `<audio>` element (same transport controls and cut-skipping playback as video). `videoEl` in the store is now `HTMLMediaElement`; `videoUrl` renamed to `mediaUrl`.
- **Export** — audio-only path uses ffmpeg `atrim` + `concat` into **M4A (AAC)**. Video export path is unchanged (MP4).
- **Copy / README** — wording updated from video-only to media (video or audio).

## Testing

Headless Chromium against a production build with a WAV fixture:

- Transcript produced (24 words)
- Audio card + `<audio>` present, no `<video>`
- Word cut works
- Export M4A: 11.43s → 10.73s (verified with ffprobe)
- `npm run lint` and `npm run build` pass


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

