### PR TITLE
Fix Whisper hallucination loops on longer transcripts (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the media. Export the final cut — without your file ever leaving your device.
 
 - 🔒 **Private by design** — no server, no auth, no uploads; all media processing happens on-device
 - 📝 **Word-level editing** — select words, press ⌫, the cut follows the text
-- 🧹 **Filler removal** — one-click cut of "um", "uh", and similar fillers (use Verbatim mode to keep them in the transcript)
+- 🧹 **Filler removal** — one-click cut of "um", "uh", and similar fillers
 - 🗣️ **Speaker diarization** — the transcript is grouped by speaker
 - 🎬 **Timeline** — waveform, word labels, cut regions, playhead, zoom
 - ⚡ **Live preview** — playback skips your cuts in real time
@@ -31,7 +31,7 @@ the media. Export the final cut — without your file ever leaving your device.
 | Piece | Tech |
 | --- | --- |
 | App | [Next.js](https://nextjs.org) + React + TypeScript + Tailwind |
-| Transcription | [transformers.js](https://github.com/huggingface/transformers.js) running [`whisper-base_timestamped`](https://huggingface.co/onnx-community/whisper-base_timestamped) (WebGPU with WASM fallback) in a Web Worker |
+| Transcription | [transformers.js](https://github.com/huggingface/transformers.js) running [`whisper-base_timestamped`](https://huggingface.co/onnx-community/whisper-base_timestamped) or [`whisper-small_timestamped`](https://huggingface.co/onnx-community/whisper-small_timestamped) (WebGPU with WASM fallback) in a Web Worker |
 | Speaker labels | [`pyannote-segmentation-3.0`](https://huggingface.co/onnx-community/pyannote-segmentation-3.0) (ONNX) |
 | Media processing | [ffmpeg.wasm](https://ffmpegwasm.netlify.app/) (multi-threaded) for audio extraction and export |
 | State | zustand |
@@ -48,19 +48,21 @@ npm run lint    # eslint
 Open [http://localhost:3000](http://localhost:3000) and drop in a video with an
 audio track.
 
-> **Note on "offline":** the AI models (~90 MB total) are downloaded from the
-> Hugging Face Hub the *first* time you transcribe, then cached in browser
-> storage. After that, everything — transcription, editing, export — works with
-> the network fully disconnected. Your media and transcript never leave the
-> device; the only third-party request the app makes is anonymous page
-> analytics (Google Analytics), which fails silently when offline.
+> **Note on "offline":** the AI models (Whisper Base ~200 MB, or Small ~600 MB,
+> plus a small speaker model) are downloaded from the Hugging Face Hub the
+> *first* time you transcribe, then cached in browser storage. After that,
+> everything — transcription, editing, export — works with the network fully
+> disconnected. Your media and transcript never leave the device; the only
+> third-party request the app makes is anonymous page analytics (Google
+> Analytics), which fails silently when offline.
 
 ## How it works
 
 1. **Extract** — ffmpeg.wasm decodes the audio track to mono 16 kHz PCM.
 2. **Transcribe** — Whisper runs in a Web Worker with `return_timestamps: "word"`,
    streaming text as it goes; pyannote assigns a speaker to every word.
-   **Verbatim** mode prompts Whisper to keep filler words so they can be edited.
+   Choose **Whisper Base** or **Whisper Small** on the homepage; both are
+   prompted to keep filler words so they can be edited.
 3. **Edit** — deleting words produces "cut ranges" of the original media. The
    preview player skips them in real time and the timeline shows them in red.
    **Remove fillers** cuts every detected "um" / "uh" / etc. in one click.

--- a/components/ModelSelector.tsx
+++ b/components/ModelSelector.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { AudioLines, ChevronDown } from "lucide-react";
+import { MODEL_ORDER, MODELS, type ModelChoice } from "@/lib/models";
+import { useEditorStore } from "@/lib/store";
+
+/**
+ * Compact model picker for the upload screen. Opens upward like a popover
+ * menu: group label + icon/name rows, with the trigger showing the current
+ * choice.
+ */
+export default function ModelSelector() {
+  const model = useEditorStore((s) => s.model);
+  const setModel = useEditorStore((s) => s.setModel);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+  const current = MODELS[model];
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const select = (choice: ModelChoice) => {
+    setModel(choice);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={rootRef} className="relative flex justify-center">
+      {open && (
+        <div
+          id={listId}
+          role="listbox"
+          aria-label="Speech model"
+          className="absolute bottom-[calc(100%+0.5rem)] z-20 w-[min(100%,18rem)] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
+        >
+          <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
+            Speech model
+          </p>
+          <div className="p-1 pb-1.5">
+            {MODEL_ORDER.map((id) => {
+              const info = MODELS[id];
+              const selected = id === model;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  onClick={() => select(id)}
+                  className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition ${
+                    selected
+                      ? "bg-zinc-100 text-zinc-900"
+                      : "text-zinc-700 hover:bg-zinc-50"
+                  }`}
+                >
+                  <AudioLines
+                    size={15}
+                    className={selected ? "text-zinc-700" : "text-zinc-400"}
+                  />
+                  <span className="min-w-0 flex-1 text-[13px] font-medium leading-tight">
+                    {info.label}
+                  </span>
+                  <span className="shrink-0 text-[11px] text-zinc-400">{info.size}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listId}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-[13px] font-medium text-zinc-800 shadow-sm shadow-zinc-900/5 transition hover:border-zinc-300 hover:bg-zinc-50"
+      >
+        <AudioLines size={14} className="text-zinc-500" />
+        <span>{current.label}</span>
+        <ChevronDown
+          size={14}
+          className={`text-zinc-400 transition ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/components/ModelSelector.tsx
+++ b/components/ModelSelector.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { AudioLines, ChevronDown } from "lucide-react";
 import { MODEL_ORDER, MODELS, type ModelChoice } from "@/lib/models";
-import { useEditorStore } from "@/lib/store";
+import { hydrateModelPreference, useEditorStore } from "@/lib/store";
 
 /**
  * Compact model picker for the upload screen. Opens upward like a popover
@@ -17,6 +17,10 @@ export default function ModelSelector() {
   const rootRef = useRef<HTMLDivElement>(null);
   const listId = useId();
   const current = MODELS[model];
+
+  useEffect(() => {
+    hydrateModelPreference();
+  }, []);
 
   useEffect(() => {
     if (!open) return;

--- a/components/ModelSelector.tsx
+++ b/components/ModelSelector.tsx
@@ -6,8 +6,8 @@ import { MODEL_ORDER, MODELS, type ModelChoice } from "@/lib/models";
 import { hydrateModelPreference, useEditorStore } from "@/lib/store";
 
 /**
- * Compact model picker for the upload screen. Opens upward like a popover
- * menu: group label + icon/name rows, with the trigger showing the current
+ * Compact model picker for the upload screen header. Opens downward under the
+ * trigger: group label + icon/name rows, with the trigger showing the current
  * choice.
  */
 export default function ModelSelector() {
@@ -44,13 +44,29 @@ export default function ModelSelector() {
   };
 
   return (
-    <div ref={rootRef} className="relative flex justify-center">
+    <div ref={rootRef} className="relative shrink-0">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listId}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-[13px] font-medium text-zinc-800 shadow-sm shadow-zinc-900/5 transition hover:border-zinc-300 hover:bg-zinc-50"
+      >
+        <AudioLines size={14} className="text-zinc-500" />
+        <span>{current.label}</span>
+        <ChevronDown
+          size={14}
+          className={`text-zinc-400 transition ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
       {open && (
         <div
           id={listId}
           role="listbox"
           aria-label="Speech model"
-          className="absolute bottom-[calc(100%+0.5rem)] z-20 w-[min(100%,18rem)] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
+          className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
         >
           <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
             Speech model
@@ -86,22 +102,6 @@ export default function ModelSelector() {
           </div>
         </div>
       )}
-
-      <button
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={listId}
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-[13px] font-medium text-zinc-800 shadow-sm shadow-zinc-900/5 transition hover:border-zinc-300 hover:bg-zinc-50"
-      >
-        <AudioLines size={14} className="text-zinc-500" />
-        <span>{current.label}</span>
-        <ChevronDown
-          size={14}
-          className={`text-zinc-400 transition ${open ? "rotate-180" : ""}`}
-        />
-      </button>
     </div>
   );
 }

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -14,6 +14,7 @@ import {
   Type,
 } from "lucide-react";
 import logo from "@/assets/logo.png";
+import ModelSelector from "./ModelSelector";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
 import { detectMediaKind, MEDIA_ACCEPT } from "@/lib/media";
 
@@ -182,6 +183,10 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
             className="hidden"
             onChange={(e) => handleFiles(e.target.files)}
           />
+        </div>
+
+        <div className="mt-4">
+          <ModelSelector />
         </div>
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -96,16 +96,19 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
   return (
     <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-zinc-50 to-neutral-50/50 p-6">
       <div className="w-full max-w-xl">
-        <div className="mb-6 flex justify-center">
-          <Image
-            src={logo}
-            alt="Rescript"
-            width={24}
-            height={24}
-            priority
-            className="rounded-sm border border-zinc-200"
-          />
-          <p className="text-[15px] font-medium text-zinc-800 ml-2">Rescript</p>
+        <div className="mb-6 flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center">
+            <Image
+              src={logo}
+              alt="Rescript"
+              width={24}
+              height={24}
+              priority
+              className="rounded-sm border border-zinc-200"
+            />
+            <p className="ml-2 text-[15px] font-medium text-zinc-800">Rescript</p>
+          </div>
+          <ModelSelector />
         </div>
         <div
           role="button"
@@ -183,10 +186,6 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
             className="hidden"
             onChange={(e) => handleFiles(e.target.files)}
           />
-        </div>
-
-        <div className="mt-4">
-          <ModelSelector />
         </div>
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">

--- a/lib/hallucinations.ts
+++ b/lib/hallucinations.ts
@@ -18,7 +18,7 @@ const HALLUCINATION_PHRASES = [
   "subtitles by the amara.org community",
   "subtitles by",
   "www.youtube.com",
-];
+].map((p) => p.split(/\s+/));
 
 function normalizeToken(text: string): string {
   return text.toLowerCase().replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}'-]+$/gu, "");
@@ -86,13 +86,11 @@ export function stripHallucinationPhrases(words: Word[]): Word[] {
   if (words.length === 0) return words;
   const keys = words.map(wordKey);
   const drop = new Array(words.length).fill(false);
-  const phrases = HALLUCINATION_PHRASES.map((p) => p.split(/\s+/));
 
   for (let i = 0; i < keys.length; i++) {
-    for (const phrase of phrases) {
+    for (const phrase of HALLUCINATION_PHRASES) {
       if (i + phrase.length > keys.length) continue;
-      const match = phrase.every((tok, j) => keys[i + j] === tok);
-      if (match) {
+      if (phrase.every((tok, j) => keys[i + j] === tok)) {
         for (let j = 0; j < phrase.length; j++) drop[i + j] = true;
       }
     }
@@ -106,13 +104,15 @@ export function stripHallucinationPhrases(words: Word[]): Word[] {
  */
 export function trimTrailingDegenerateTail(words: Word[]): Word[] {
   if (words.length < 8) return words;
-  // Walk backwards counting how many of the last tokens share the same key
-  // as their immediate neighbors in a small window.
-  let cutFrom = words.length;
+  const keys = words.map(wordKey);
   const window = 6;
+  let cutFrom = words.length;
+
   for (let i = words.length - 1; i >= window; i--) {
-    const slice = words.slice(i - window + 1, i + 1).map(wordKey);
-    const unique = new Set(slice.filter(Boolean));
+    const unique = new Set<string>();
+    for (let j = i - window + 1; j <= i; j++) {
+      if (keys[j]) unique.add(keys[j]!);
+    }
     // Degenerate: ≤2 distinct tokens in a 6-word window near the end.
     if (unique.size > 0 && unique.size <= 2) {
       cutFrom = i - window + 1;

--- a/lib/hallucinations.ts
+++ b/lib/hallucinations.ts
@@ -1,0 +1,134 @@
+import type { Word } from "./types";
+
+/**
+ * Known Whisper hallucination phrases. These often appear as sudden topic
+ * shifts near silence, music, or chunk boundaries — especially with the
+ * smaller base model on longer audio.
+ */
+const HALLUCINATION_PHRASES = [
+  "i'm sorry",
+  "i am sorry",
+  "thank you for watching",
+  "thanks for watching",
+  "please subscribe",
+  "like and subscribe",
+  "subscribe to my channel",
+  "see you next time",
+  "thanks for listening",
+  "subtitles by the amara.org community",
+  "subtitles by",
+  "www.youtube.com",
+];
+
+function normalizeToken(text: string): string {
+  return text.toLowerCase().replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}'-]+$/gu, "");
+}
+
+function wordKey(w: Word): string {
+  return normalizeToken(w.text);
+}
+
+/**
+ * Collapse consecutive repeating n-grams (e.g. "little bit of a" × N) down to
+ * a single occurrence. Walks greedily left-to-right. Among candidates at each
+ * position, prefers the collapse that removes the most words (so "little bit
+ * of a" ×4 wins over that phrase-pair ×2). Longer phrases need only 2
+ * consecutive copies; short ones need 3 to avoid collapsing "yes yes yes".
+ */
+export function collapseRepeatingNgrams(
+  words: Word[],
+  { minN = 2, maxN = 8 }: { minN?: number; maxN?: number } = {}
+): Word[] {
+  if (words.length < minN * 2) return words;
+  const keys = words.map(wordKey);
+  const out: Word[] = [];
+  let i = 0;
+  while (i < words.length) {
+    const maxLen = Math.min(maxN, Math.floor((words.length - i) / 2));
+    let bestN = 0;
+    let bestRepeats = 0;
+    for (let n = maxLen; n >= minN; n--) {
+      const minRepeats = n >= 4 ? 2 : 3;
+      if (i + n * minRepeats > words.length) continue;
+      const unit = keys.slice(i, i + n);
+      if (unit.some((k) => !k)) continue;
+      let repeats = 1;
+      while (
+        i + (repeats + 1) * n <= words.length &&
+        unit.every((k, j) => keys[i + repeats * n + j] === k)
+      ) {
+        repeats++;
+      }
+      if (repeats < minRepeats) continue;
+      const removed = (repeats - 1) * n;
+      const bestRemoved = (bestRepeats - 1) * bestN;
+      if (removed > bestRemoved || (removed === bestRemoved && repeats > bestRepeats)) {
+        bestN = n;
+        bestRepeats = repeats;
+      }
+    }
+    if (bestN > 0) {
+      out.push(...words.slice(i, i + bestN));
+      i += bestRepeats * bestN;
+    } else {
+      out.push(words[i]);
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Drop known hallucination phrases when they appear as contiguous runs.
+ * Only removes phrases that are fully matched; surrounding real speech is kept.
+ */
+export function stripHallucinationPhrases(words: Word[]): Word[] {
+  if (words.length === 0) return words;
+  const keys = words.map(wordKey);
+  const drop = new Array(words.length).fill(false);
+  const phrases = HALLUCINATION_PHRASES.map((p) => p.split(/\s+/));
+
+  for (let i = 0; i < keys.length; i++) {
+    for (const phrase of phrases) {
+      if (i + phrase.length > keys.length) continue;
+      const match = phrase.every((tok, j) => keys[i + j] === tok);
+      if (match) {
+        for (let j = 0; j < phrase.length; j++) drop[i + j] = true;
+      }
+    }
+  }
+  return words.filter((_, i) => !drop[i]);
+}
+
+/**
+ * Drop a trailing run of near-identical short words that often appears when
+ * Whisper loops at the end of a clip (e.g. a dozen "um" / "you" / "." tokens).
+ */
+export function trimTrailingDegenerateTail(words: Word[]): Word[] {
+  if (words.length < 8) return words;
+  // Walk backwards counting how many of the last tokens share the same key
+  // as their immediate neighbors in a small window.
+  let cutFrom = words.length;
+  const window = 6;
+  for (let i = words.length - 1; i >= window; i--) {
+    const slice = words.slice(i - window + 1, i + 1).map(wordKey);
+    const unique = new Set(slice.filter(Boolean));
+    // Degenerate: ≤2 distinct tokens in a 6-word window near the end.
+    if (unique.size > 0 && unique.size <= 2) {
+      cutFrom = i - window + 1;
+    } else if (cutFrom < words.length) {
+      break;
+    }
+  }
+  // Only trim if we'd drop a meaningful chunk (≥6 words) of the tail.
+  if (words.length - cutFrom >= 6) return words.slice(0, cutFrom);
+  return words;
+}
+
+/** Apply all hallucination cleanups and re-index word ids. */
+export function cleanTranscript(words: Word[]): Word[] {
+  let cleaned = collapseRepeatingNgrams(words);
+  cleaned = stripHallucinationPhrases(cleaned);
+  cleaned = trimTrailingDegenerateTail(cleaned);
+  return cleaned.map((w, i) => (w.id === i ? w : { ...w, id: i }));
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,5 +1,5 @@
 /** Transcription model choices offered on the upload screen. */
-export type ModelChoice = "fast" | "verbatim";
+export type ModelChoice = "base" | "small";
 
 type DType = "fp32" | "fp16" | "q8" | "int8" | "uint8" | "q4" | "q4f16" | "bnb4";
 
@@ -28,30 +28,35 @@ export interface ModelInfo {
   verbatimPrompt?: string;
 }
 
-const WHISPER_BASE = "onnx-community/whisper-base_timestamped";
-const WHISPER_BASE_DTYPE = {
+/** Display order for the homepage model dropdown. */
+export const MODEL_ORDER: ModelChoice[] = ["base", "small"];
+
+const WHISPER_DTYPE = {
   // q4 decoder: q8 fails session creation on onnxruntime-web 1.26
   // (Missing required scale … MatMulNBits).
   webgpu: { encoder_model: "fp32", decoder_model_merged: "q4" },
   wasm: { encoder_model: "fp32", decoder_model_merged: "q4" },
 } satisfies ModelInfo["dtype"];
 
+/** Shared prompt so both sizes keep um/uh for filler editing. */
+const VERBATIM_PROMPT =
+  "Umm, let me think like, hmm... Okay, here's what I'm, like, thinking, um, yeah.";
+
 export const MODELS: Record<ModelChoice, ModelInfo> = {
-  fast: {
-    id: WHISPER_BASE,
-    label: "Standard",
-    description: "Fast on any device. May clean up filler words (\u201cum\u201d, \u201cuh\u201d).",
-    size: "~80 MB",
-    dtype: WHISPER_BASE_DTYPE,
+  base: {
+    id: "onnx-community/whisper-base_timestamped",
+    label: "Whisper Base",
+    description: "Faster download and transcription. Good for most clips.",
+    size: "~200 MB",
+    dtype: WHISPER_DTYPE,
+    verbatimPrompt: VERBATIM_PROMPT,
   },
-  verbatim: {
-    id: WHISPER_BASE,
-    label: "Verbatim",
-    description:
-      "Tries to keep filler words (\u201cum\u201d, \u201cuh\u201d) in the transcript so you can cut them. Same speed and size.",
-    size: "~80 MB",
-    dtype: WHISPER_BASE_DTYPE,
-    verbatimPrompt:
-      "Umm, let me think like, hmm... Okay, here's what I'm, like, thinking, um, yeah.",
+  small: {
+    id: "onnx-community/whisper-small_timestamped",
+    label: "Whisper Small",
+    description: "More accurate on longer or noisier audio. Larger download.",
+    size: "~600 MB",
+    dtype: WHISPER_DTYPE,
+    verbatimPrompt: VERBATIM_PROMPT,
   },
 };

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -52,6 +52,9 @@ export const MODELS: Record<ModelChoice, ModelInfo> = {
     size: "~80 MB",
     dtype: WHISPER_BASE_DTYPE,
     verbatimPrompt:
-      "Umm, let me think like, hmm... Okay, here's what I'm, like, thinking, um, yeah.",
+      // Keep this short and free of "I'm …" openers — a longer prompt that
+      // starts with "I'm" can seed the common "I'm sorry" hallucination loop
+      // on later chunks of long audio.
+      "Um, uh, hmm, er, ah.",
   },
 };

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -60,3 +60,31 @@ export const MODELS: Record<ModelChoice, ModelInfo> = {
     verbatimPrompt: VERBATIM_PROMPT,
   },
 };
+
+const MODEL_STORAGE_KEY = "rescript.model";
+
+export function isModelChoice(value: unknown): value is ModelChoice {
+  return typeof value === "string" && value in MODELS;
+}
+
+/** Read the last-selected model from localStorage (defaults to base). */
+export function loadModelPreference(): ModelChoice {
+  if (typeof window === "undefined") return "base";
+  try {
+    const raw = window.localStorage.getItem(MODEL_STORAGE_KEY);
+    if (isModelChoice(raw)) return raw;
+  } catch {
+    // private mode / disabled storage
+  }
+  return "base";
+}
+
+/** Persist the selected model for the next visit. */
+export function saveModelPreference(model: ModelChoice) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MODEL_STORAGE_KEY, model);
+  } catch {
+    // private mode / disabled storage
+  }
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -52,9 +52,6 @@ export const MODELS: Record<ModelChoice, ModelInfo> = {
     size: "~80 MB",
     dtype: WHISPER_BASE_DTYPE,
     verbatimPrompt:
-      // Keep this short and free of "I'm …" openers — a longer prompt that
-      // starts with "I'm" can seed the common "I'm sorry" hallucination loop
-      // on later chunks of long audio.
-      "Um, uh, hmm, er, ah.",
+      "Umm, let me think like, hmm... Okay, here's what I'm, like, thinking, um, yeah.",
   },
 };

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import type { EditorStatus, ProgressInfo, Word } from "./types";
 import type { ModelChoice } from "./models";
+import { loadModelPreference, saveModelPreference } from "./models";
 import { detectMediaKind, type MediaKind } from "./media";
 
 interface EditorState {
@@ -109,7 +110,10 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       exportUrl: null,
     });
   },
-  setModel: (model) => set({ model }),
+  setModel: (model) => {
+    saveModelPreference(model);
+    set({ model });
+  },
   setDuration: (duration) => set({ duration }),
   setAudio: (audio) => set({ audio }),
   setStatus: (status) => set({ status }),
@@ -235,3 +239,11 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     });
   },
 }));
+
+/** Apply the stored model choice after mount (avoids SSR/localStorage mismatch). */
+export function hydrateModelPreference() {
+  const stored = loadModelPreference();
+  if (stored !== useEditorStore.getState().model) {
+    useEditorStore.setState({ model: stored });
+  }
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -70,7 +70,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   mediaKind: null,
   duration: 0,
   audio: null,
-  model: "verbatim",
+  model: "base",
 
   status: "idle",
   progress: { message: "", value: null },

--- a/lib/vad.ts
+++ b/lib/vad.ts
@@ -1,0 +1,144 @@
+/**
+ * Voice-activity helpers used to reduce Whisper hallucinations on long
+ * silence / music stretches.
+ *
+ * Strategy: detect speech frames, then zero out contiguous silent regions
+ * longer than a threshold. Timeline length is preserved so word timestamps
+ * stay aligned with the media.
+ */
+
+export const VAD_SAMPLE_RATE = 16_000;
+/** Silero VAD expects 512-sample frames at 16 kHz (~32 ms). */
+export const VAD_FRAME_SIZE = 512;
+
+export interface MuteSilenceOptions {
+  /** Minimum contiguous silence (seconds) to mute. Default 1.5. */
+  minSilenceS?: number;
+  /** Keep this much audio (seconds) on each side of speech. Default 0.25. */
+  padS?: number;
+  frameSize?: number;
+}
+
+/**
+ * Expand speech regions by `padFrames` on each side, then mark long silent
+ * gaps as mute targets. Returns a per-sample boolean mask where `true` means
+ * "keep" (speech or short pause).
+ */
+export function keepMaskFromSpeechFrames(
+  speechFrames: boolean[],
+  totalSamples: number,
+  {
+    minSilenceS = 1.5,
+    padS = 0.25,
+    frameSize = VAD_FRAME_SIZE,
+    sampleRate = VAD_SAMPLE_RATE,
+  }: MuteSilenceOptions & { sampleRate?: number } = {}
+): boolean[] {
+  const n = speechFrames.length;
+  if (n === 0 || totalSamples === 0) {
+    return new Array(totalSamples).fill(false);
+  }
+
+  const padFrames = Math.max(0, Math.round((padS * sampleRate) / frameSize));
+  const minSilenceFrames = Math.max(
+    1,
+    Math.round((minSilenceS * sampleRate) / frameSize)
+  );
+
+  // Dilate speech so we don't clip phoneme edges.
+  const padded = speechFrames.slice();
+  for (let i = 0; i < n; i++) {
+    if (!speechFrames[i]) continue;
+    const lo = Math.max(0, i - padFrames);
+    const hi = Math.min(n - 1, i + padFrames);
+    for (let j = lo; j <= hi; j++) padded[j] = true;
+  }
+
+  // Start by keeping everything; only mute long silent runs.
+  const keepFrames = new Array(n).fill(true);
+  let i = 0;
+  while (i < n) {
+    if (padded[i]) {
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < n && !padded[j]) j++;
+    if (j - i >= minSilenceFrames) {
+      for (let k = i; k < j; k++) keepFrames[k] = false;
+    }
+    i = j;
+  }
+
+  const keep = new Array(totalSamples).fill(false);
+  for (let f = 0; f < n; f++) {
+    if (!keepFrames[f]) continue;
+    const start = f * frameSize;
+    const end = Math.min(totalSamples, start + frameSize);
+    for (let s = start; s < end; s++) keep[s] = true;
+  }
+  // Trailing partial frame after the last full VAD frame.
+  if (n * frameSize < totalSamples && keepFrames[n - 1]) {
+    for (let s = n * frameSize; s < totalSamples; s++) keep[s] = true;
+  }
+  return keep;
+}
+
+/**
+ * Return a copy of `audio` with long silent regions zeroed. Short pauses
+ * inside speech are left intact.
+ */
+export function muteLongSilence(
+  audio: Float32Array,
+  speechFrames: boolean[],
+  options?: MuteSilenceOptions
+): Float32Array {
+  const frameSize = options?.frameSize ?? VAD_FRAME_SIZE;
+  const keep = keepMaskFromSpeechFrames(speechFrames, audio.length, {
+    ...options,
+    frameSize,
+  });
+  const out = new Float32Array(audio.length);
+  for (let i = 0; i < audio.length; i++) {
+    if (keep[i]) out[i] = audio[i];
+  }
+  return out;
+}
+
+/**
+ * Lightweight energy-based speech detector used when Silero VAD is unavailable.
+ * Frames whose RMS is above `floor * relativeThreshold` (or an absolute floor)
+ * are treated as speech.
+ */
+export function energySpeechFrames(
+  audio: Float32Array,
+  {
+    frameSize = VAD_FRAME_SIZE,
+    relativeThreshold = 0.15,
+    absoluteFloor = 0.005,
+  }: {
+    frameSize?: number;
+    relativeThreshold?: number;
+    absoluteFloor?: number;
+  } = {}
+): boolean[] {
+  const n = Math.ceil(audio.length / frameSize) || 0;
+  const energies = new Float32Array(n);
+  let peak = 0;
+  for (let f = 0; f < n; f++) {
+    const start = f * frameSize;
+    const end = Math.min(audio.length, start + frameSize);
+    let sum = 0;
+    for (let i = start; i < end; i++) {
+      const x = audio[i];
+      sum += x * x;
+    }
+    const rms = Math.sqrt(sum / Math.max(1, end - start));
+    energies[f] = rms;
+    if (rms > peak) peak = rms;
+  }
+  const cutoff = Math.max(absoluteFloor, peak * relativeThreshold);
+  const out: boolean[] = new Array(n);
+  for (let f = 0; f < n; f++) out[f] = energies[f] >= cutoff;
+  return out;
+}

--- a/lib/vad.ts
+++ b/lib/vad.ts
@@ -34,7 +34,11 @@ export interface SpeechSegmentOptions {
 
 /**
  * Build contiguous speech segments from per-frame speech flags.
- * Short silent gaps are absorbed; long gaps become segment boundaries.
+ *
+ * 1. Collect raw speech runs
+ * 2. Expand each run by `padS`
+ * 3. Merge runs whose gap is shorter than `maxGapS`
+ * 4. Drop runs shorter than `minSpeechS`
  */
 export function speechSegmentsFromFrames(
   speechFrames: boolean[],
@@ -51,62 +55,43 @@ export function speechSegmentsFromFrames(
   if (n === 0 || totalSamples === 0) return [];
 
   const padFrames = Math.max(0, Math.round((padS * sampleRate) / frameSize));
-  const maxGapFrames = Math.max(
-    1,
-    Math.round((maxGapS * sampleRate) / frameSize)
-  );
-  const minSpeechSamples = Math.max(
-    1,
-    Math.round(minSpeechS * sampleRate)
-  );
+  const maxGapFrames = Math.max(1, Math.round((maxGapS * sampleRate) / frameSize));
+  const minSpeechSamples = Math.max(1, Math.round(minSpeechS * sampleRate));
 
-  // Dilate speech so we don't clip phoneme edges.
-  const padded = speechFrames.slice();
-  for (let i = 0; i < n; i++) {
-    if (!speechFrames[i]) continue;
-    const lo = Math.max(0, i - padFrames);
-    const hi = Math.min(n - 1, i + padFrames);
-    for (let j = lo; j <= hi; j++) padded[j] = true;
-  }
-
-  // Absorb short silent gaps so a breath does not split a sentence.
-  const merged = padded.slice();
-  let i = 0;
-  while (i < n) {
-    if (merged[i]) {
+  // Raw [start, end) frame runs.
+  const runs: Array<[number, number]> = [];
+  for (let i = 0; i < n; ) {
+    if (!speechFrames[i]) {
       i++;
       continue;
     }
-    let j = i;
-    while (j < n && !padded[j]) j++;
-    const gap = j - i;
-    const touchesSpeech = i > 0 && j < n;
-    if (touchesSpeech && gap < maxGapFrames) {
-      for (let k = i; k < j; k++) merged[k] = true;
-    }
+    let j = i + 1;
+    while (j < n && speechFrames[j]) j++;
+    runs.push([i, j]);
     i = j;
+  }
+  if (runs.length === 0) return [];
+
+  // Pad, then merge overlapping / nearby runs in one pass.
+  const merged: Array<[number, number]> = [];
+  for (const [rawStart, rawEnd] of runs) {
+    const start = Math.max(0, rawStart - padFrames);
+    const end = Math.min(n, rawEnd + padFrames);
+    const prev = merged[merged.length - 1];
+    if (prev && start - prev[1] < maxGapFrames) {
+      prev[1] = Math.max(prev[1], end);
+    } else {
+      merged.push([start, end]);
+    }
   }
 
-  const segments: SpeechSegment[] = [];
-  i = 0;
-  while (i < n) {
-    if (!merged[i]) {
-      i++;
-      continue;
-    }
-    let j = i;
-    while (j < n && merged[j]) j++;
-    const startSample = i * frameSize;
-    // Include a trailing partial frame when the last speech frame is the
-    // final VAD frame and samples remain past n * frameSize.
-    let endSample = Math.min(totalSamples, j * frameSize);
-    if (j === n) endSample = totalSamples;
-    if (endSample - startSample >= minSpeechSamples) {
-      segments.push({ startSample, endSample });
-    }
-    i = j;
-  }
-  return segments;
+  return merged.flatMap(([startFrame, endFrame]) => {
+    const startSample = startFrame * frameSize;
+    const endSample =
+      endFrame >= n ? totalSamples : Math.min(totalSamples, endFrame * frameSize);
+    if (endSample - startSample < minSpeechSamples) return [];
+    return [{ startSample, endSample }];
+  });
 }
 
 /**
@@ -142,7 +127,5 @@ export function energySpeechFrames(
     if (rms > peak) peak = rms;
   }
   const cutoff = Math.max(absoluteFloor, peak * relativeThreshold);
-  const out: boolean[] = new Array(n);
-  for (let f = 0; f < n; f++) out[f] = energies[f] >= cutoff;
-  return out;
+  return Array.from(energies, (e) => e >= cutoff);
 }

--- a/lib/vad.ts
+++ b/lib/vad.ts
@@ -2,47 +2,62 @@
  * Voice-activity helpers used to reduce Whisper hallucinations on long
  * silence / music stretches.
  *
- * Strategy: detect speech frames, then zero out contiguous silent regions
- * longer than a threshold. Timeline length is preserved so word timestamps
- * stay aligned with the media.
+ * Strategy: detect speech frames, merge short pauses, then return contiguous
+ * speech segments. Callers run Whisper only on those slices and remap
+ * timestamps back onto the original timeline — silent gaps are never decoded.
  */
 
 export const VAD_SAMPLE_RATE = 16_000;
 /** Silero VAD expects 512-sample frames at 16 kHz (~32 ms). */
 export const VAD_FRAME_SIZE = 512;
 
-export interface MuteSilenceOptions {
-  /** Minimum contiguous silence (seconds) to mute. Default 1.5. */
-  minSilenceS?: number;
-  /** Keep this much audio (seconds) on each side of speech. Default 0.25. */
+export interface SpeechSegment {
+  /** Inclusive start sample in the original audio. */
+  startSample: number;
+  /** Exclusive end sample in the original audio. */
+  endSample: number;
+}
+
+export interface SpeechSegmentOptions {
+  /**
+   * Gaps of silence shorter than this (seconds) are kept inside a segment
+   * (breaths, brief pauses). Longer gaps split segments. Default 1.5.
+   */
+  maxGapS?: number;
+  /** Expand each speech region by this much (seconds) on each side. Default 0.25. */
   padS?: number;
+  /** Drop segments shorter than this (seconds). Default 0.15. */
+  minSpeechS?: number;
   frameSize?: number;
+  sampleRate?: number;
 }
 
 /**
- * Expand speech regions by `padFrames` on each side, then mark long silent
- * gaps as mute targets. Returns a per-sample boolean mask where `true` means
- * "keep" (speech or short pause).
+ * Build contiguous speech segments from per-frame speech flags.
+ * Short silent gaps are absorbed; long gaps become segment boundaries.
  */
-export function keepMaskFromSpeechFrames(
+export function speechSegmentsFromFrames(
   speechFrames: boolean[],
   totalSamples: number,
   {
-    minSilenceS = 1.5,
+    maxGapS = 1.5,
     padS = 0.25,
+    minSpeechS = 0.15,
     frameSize = VAD_FRAME_SIZE,
     sampleRate = VAD_SAMPLE_RATE,
-  }: MuteSilenceOptions & { sampleRate?: number } = {}
-): boolean[] {
+  }: SpeechSegmentOptions = {}
+): SpeechSegment[] {
   const n = speechFrames.length;
-  if (n === 0 || totalSamples === 0) {
-    return new Array(totalSamples).fill(false);
-  }
+  if (n === 0 || totalSamples === 0) return [];
 
   const padFrames = Math.max(0, Math.round((padS * sampleRate) / frameSize));
-  const minSilenceFrames = Math.max(
+  const maxGapFrames = Math.max(
     1,
-    Math.round((minSilenceS * sampleRate) / frameSize)
+    Math.round((maxGapS * sampleRate) / frameSize)
+  );
+  const minSpeechSamples = Math.max(
+    1,
+    Math.round(minSpeechS * sampleRate)
   );
 
   // Dilate speech so we don't clip phoneme edges.
@@ -54,60 +69,49 @@ export function keepMaskFromSpeechFrames(
     for (let j = lo; j <= hi; j++) padded[j] = true;
   }
 
-  // Start by keeping everything; only mute long silent runs.
-  const keepFrames = new Array(n).fill(true);
+  // Absorb short silent gaps so a breath does not split a sentence.
+  const merged = padded.slice();
   let i = 0;
   while (i < n) {
-    if (padded[i]) {
+    if (merged[i]) {
       i++;
       continue;
     }
     let j = i;
     while (j < n && !padded[j]) j++;
-    if (j - i >= minSilenceFrames) {
-      for (let k = i; k < j; k++) keepFrames[k] = false;
+    const gap = j - i;
+    const touchesSpeech = i > 0 && j < n;
+    if (touchesSpeech && gap < maxGapFrames) {
+      for (let k = i; k < j; k++) merged[k] = true;
     }
     i = j;
   }
 
-  const keep = new Array(totalSamples).fill(false);
-  for (let f = 0; f < n; f++) {
-    if (!keepFrames[f]) continue;
-    const start = f * frameSize;
-    const end = Math.min(totalSamples, start + frameSize);
-    for (let s = start; s < end; s++) keep[s] = true;
+  const segments: SpeechSegment[] = [];
+  i = 0;
+  while (i < n) {
+    if (!merged[i]) {
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < n && merged[j]) j++;
+    const startSample = i * frameSize;
+    // Include a trailing partial frame when the last speech frame is the
+    // final VAD frame and samples remain past n * frameSize.
+    let endSample = Math.min(totalSamples, j * frameSize);
+    if (j === n) endSample = totalSamples;
+    if (endSample - startSample >= minSpeechSamples) {
+      segments.push({ startSample, endSample });
+    }
+    i = j;
   }
-  // Trailing partial frame after the last full VAD frame.
-  if (n * frameSize < totalSamples && keepFrames[n - 1]) {
-    for (let s = n * frameSize; s < totalSamples; s++) keep[s] = true;
-  }
-  return keep;
-}
-
-/**
- * Return a copy of `audio` with long silent regions zeroed. Short pauses
- * inside speech are left intact.
- */
-export function muteLongSilence(
-  audio: Float32Array,
-  speechFrames: boolean[],
-  options?: MuteSilenceOptions
-): Float32Array {
-  const frameSize = options?.frameSize ?? VAD_FRAME_SIZE;
-  const keep = keepMaskFromSpeechFrames(speechFrames, audio.length, {
-    ...options,
-    frameSize,
-  });
-  const out = new Float32Array(audio.length);
-  for (let i = 0; i < audio.length; i++) {
-    if (keep[i]) out[i] = audio[i];
-  }
-  return out;
+  return segments;
 }
 
 /**
  * Lightweight energy-based speech detector used when Silero VAD is unavailable.
- * Frames whose RMS is above `floor * relativeThreshold` (or an absolute floor)
+ * Frames whose RMS is above `peak * relativeThreshold` (or an absolute floor)
  * are treated as speech.
  */
 export function energySpeechFrames(

--- a/scripts/hallucination-test.ts
+++ b/scripts/hallucination-test.ts
@@ -1,0 +1,53 @@
+import {
+  cleanTranscript,
+  collapseRepeatingNgrams,
+  stripHallucinationPhrases,
+} from "../lib/hallucinations";
+import type { Word } from "../lib/types";
+
+function w(text: string, i: number): Word {
+  return { id: i, text, start: i * 0.3, end: i * 0.3 + 0.25, speaker: 0, deleted: false };
+}
+
+function texts(words: Word[]) {
+  return words.map((x) => x.text).join(" ");
+}
+
+{
+  const loop = "little bit of a little bit of a little bit of a little bit of a"
+    .split(" ")
+    .map(w);
+  const out = collapseRepeatingNgrams(loop);
+  console.log("collapse loop:", texts(out));
+  if (texts(out) !== "little bit of a") throw new Error("expected single 'little bit of a'");
+}
+
+{
+  const words = "okay I'm sorry thanks for watching next topic".split(" ").map(w);
+  const out = stripHallucinationPhrases(words);
+  console.log("strip phrases:", texts(out));
+  if (texts(out) !== "okay next topic") throw new Error("phrase strip failed");
+}
+
+{
+  const raw =
+    "this is real speech I'm sorry little bit of a little bit of a little bit of a"
+      .split(" ")
+      .map(w);
+  const out = cleanTranscript(raw);
+  console.log("cleanTranscript:", texts(out));
+  if (!texts(out).startsWith("this is real speech")) throw new Error("lost real speech");
+  if (/i'?m sorry/i.test(texts(out))) throw new Error("sorry not stripped");
+  if ((texts(out).match(/little bit of a/g) || []).length > 1) {
+    throw new Error("loop not collapsed");
+  }
+}
+
+{
+  const words = "yes yes okay".split(" ").map(w);
+  const out = collapseRepeatingNgrams(words);
+  console.log("short repeats kept:", texts(out));
+  if (texts(out) !== "yes yes okay") throw new Error("over-collapsed short repeats");
+}
+
+console.log("ALL HALLUCINATION TESTS PASSED");

--- a/scripts/vad-test.ts
+++ b/scripts/vad-test.ts
@@ -1,0 +1,75 @@
+import {
+  VAD_FRAME_SIZE,
+  energySpeechFrames,
+  keepMaskFromSpeechFrames,
+  muteLongSilence,
+} from "../lib/vad";
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+{
+  // 3s of "speech" energy, 2s silence, 1s speech — at 16 kHz.
+  const sr = 16_000;
+  const audio = new Float32Array(sr * 6);
+  for (let i = 0; i < sr * 3; i++) audio[i] = Math.sin(i / 20) * 0.3;
+  // silence in the middle (already zeros)
+  for (let i = sr * 5; i < audio.length; i++) audio[i] = Math.sin(i / 20) * 0.3;
+
+  const frames = energySpeechFrames(audio);
+  const muted = muteLongSilence(audio, frames, { minSilenceS: 1.5, padS: 0.1 });
+
+  // Mid silence should be zeroed.
+  let midEnergy = 0;
+  for (let i = sr * 3.5; i < sr * 4.5; i++) midEnergy += Math.abs(muted[i]!);
+  assert(midEnergy === 0, "expected mid silence to be muted");
+
+  // Speech regions should survive.
+  let speechEnergy = 0;
+  for (let i = 0; i < sr; i++) speechEnergy += Math.abs(muted[i]!);
+  assert(speechEnergy > 100, "expected early speech to be kept");
+
+  speechEnergy = 0;
+  for (let i = sr * 5.2; i < sr * 5.8; i++) speechEnergy += Math.abs(muted[i]!);
+  assert(speechEnergy > 50, "expected late speech to be kept");
+
+  console.log("mute long silence: ok");
+}
+
+{
+  // Short pause (0.4s) should NOT be muted when minSilenceS is 1.5.
+  const frames = [
+    ...Array(10).fill(true),
+    ...Array(Math.round((0.4 * 16_000) / VAD_FRAME_SIZE)).fill(false),
+    ...Array(10).fill(true),
+  ];
+  const total = frames.length * VAD_FRAME_SIZE;
+  const keep = keepMaskFromSpeechFrames(frames, total, {
+    minSilenceS: 1.5,
+    padS: 0,
+  });
+  assert(
+    keep.every(Boolean),
+    "short pauses should remain when below minSilenceS"
+  );
+  console.log("short pause kept: ok");
+}
+
+{
+  const frames = [
+    ...Array(5).fill(true),
+    ...Array(Math.round((2 * 16_000) / VAD_FRAME_SIZE)).fill(false),
+    ...Array(5).fill(true),
+  ];
+  const total = frames.length * VAD_FRAME_SIZE;
+  const keep = keepMaskFromSpeechFrames(frames, total, {
+    minSilenceS: 1.5,
+    padS: 0,
+  });
+  const mutedCount = keep.filter((k) => !k).length;
+  assert(mutedCount > 16_000, "expected >1s of muted samples");
+  console.log("long silence muted: ok");
+}
+
+console.log("ALL VAD TESTS PASSED");

--- a/scripts/vad-test.ts
+++ b/scripts/vad-test.ts
@@ -1,8 +1,7 @@
 import {
   VAD_FRAME_SIZE,
   energySpeechFrames,
-  keepMaskFromSpeechFrames,
-  muteLongSilence,
+  speechSegmentsFromFrames,
 } from "../lib/vad";
 
 function assert(cond: boolean, msg: string) {
@@ -10,50 +9,42 @@ function assert(cond: boolean, msg: string) {
 }
 
 {
-  // 3s of "speech" energy, 2s silence, 1s speech — at 16 kHz.
+  // 3s speech, 2s silence, 1s speech — at 16 kHz.
   const sr = 16_000;
   const audio = new Float32Array(sr * 6);
   for (let i = 0; i < sr * 3; i++) audio[i] = Math.sin(i / 20) * 0.3;
-  // silence in the middle (already zeros)
   for (let i = sr * 5; i < audio.length; i++) audio[i] = Math.sin(i / 20) * 0.3;
 
   const frames = energySpeechFrames(audio);
-  const muted = muteLongSilence(audio, frames, { minSilenceS: 1.5, padS: 0.1 });
+  const segs = speechSegmentsFromFrames(frames, audio.length, {
+    maxGapS: 1.5,
+    padS: 0.1,
+  });
 
-  // Mid silence should be zeroed.
-  let midEnergy = 0;
-  for (let i = sr * 3.5; i < sr * 4.5; i++) midEnergy += Math.abs(muted[i]!);
-  assert(midEnergy === 0, "expected mid silence to be muted");
-
-  // Speech regions should survive.
-  let speechEnergy = 0;
-  for (let i = 0; i < sr; i++) speechEnergy += Math.abs(muted[i]!);
-  assert(speechEnergy > 100, "expected early speech to be kept");
-
-  speechEnergy = 0;
-  for (let i = sr * 5.2; i < sr * 5.8; i++) speechEnergy += Math.abs(muted[i]!);
-  assert(speechEnergy > 50, "expected late speech to be kept");
-
-  console.log("mute long silence: ok");
+  assert(segs.length === 2, `expected 2 speech segments, got ${segs.length}`);
+  assert(segs[0]!.startSample < sr, "first segment should start near 0");
+  assert(segs[0]!.endSample < sr * 3.5, "first segment should end before mid silence");
+  assert(segs[1]!.startSample > sr * 4.5, "second segment should start after silence");
+  // Whisper never sees the silent mid region.
+  const covered = segs.reduce((n, s) => n + (s.endSample - s.startSample), 0);
+  assert(covered < audio.length - sr, "silence should be excluded from coverage");
+  console.log("skip long silence: ok", segs);
 }
 
 {
-  // Short pause (0.4s) should NOT be muted when minSilenceS is 1.5.
+  // Short pause (0.4s) should NOT split when maxGapS is 1.5.
   const frames = [
     ...Array(10).fill(true),
     ...Array(Math.round((0.4 * 16_000) / VAD_FRAME_SIZE)).fill(false),
     ...Array(10).fill(true),
   ];
   const total = frames.length * VAD_FRAME_SIZE;
-  const keep = keepMaskFromSpeechFrames(frames, total, {
-    minSilenceS: 1.5,
+  const segs = speechSegmentsFromFrames(frames, total, {
+    maxGapS: 1.5,
     padS: 0,
   });
-  assert(
-    keep.every(Boolean),
-    "short pauses should remain when below minSilenceS"
-  );
-  console.log("short pause kept: ok");
+  assert(segs.length === 1, `short pause should merge into one segment, got ${segs.length}`);
+  console.log("short pause merged: ok");
 }
 
 {
@@ -63,13 +54,20 @@ function assert(cond: boolean, msg: string) {
     ...Array(5).fill(true),
   ];
   const total = frames.length * VAD_FRAME_SIZE;
-  const keep = keepMaskFromSpeechFrames(frames, total, {
-    minSilenceS: 1.5,
+  const segs = speechSegmentsFromFrames(frames, total, {
+    maxGapS: 1.5,
     padS: 0,
   });
-  const mutedCount = keep.filter((k) => !k).length;
-  assert(mutedCount > 16_000, "expected >1s of muted samples");
-  console.log("long silence muted: ok");
+  assert(segs.length === 2, `expected split on 2s gap, got ${segs.length}`);
+  console.log("long silence splits: ok");
+}
+
+{
+  // All silence → no segments.
+  const frames = Array(20).fill(false);
+  const segs = speechSegmentsFromFrames(frames, 20 * VAD_FRAME_SIZE);
+  assert(segs.length === 0, "all silence should yield no segments");
+  console.log("all silence empty: ok");
 }
 
 console.log("ALL VAD TESTS PASSED");

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -101,8 +101,7 @@ async function pickDevice(): Promise<"webgpu" | "wasm"> {
   return "wasm";
 }
 
-// Keyed by model id: choices that share the same underlying model (e.g.
-// "fast" and "verbatim", which differ only in prompting) share one pipeline.
+// Keyed by model id so choices that share weights reuse one pipeline.
 const asrPromises = new Map<string, Promise<AutomaticSpeechRecognitionPipeline>>();
 async function getAsr(choice: ModelChoice) {
   const { id, dtype } = MODELS[choice];
@@ -383,7 +382,7 @@ function assignSpeakers(words: Word[], segments: DiarizationSegment[]) {
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
   const { audio, duration, model, language } = event.data;
   try {
-    const choice = model ?? "fast";
+    const choice = model ?? "base";
 
     // Overlap Whisper + Silero downloads; diarizer warms in the background.
     getDiarizer().catch(() => {});

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -47,18 +47,50 @@ const post = (msg: WorkerResponse, transfer: Transferable[] = []) =>
   (self as unknown as Worker).postMessage(msg, transfer);
 
 /**
- * Aggregate multi-file download progress into a single 0..1 value.
+ * Aggregate model download progress into a single 0..1 value.
  *
- * Files are discovered progressively, so the naive loaded/total ratio can
- * *drop* whenever a new file starts reporting (the denominator suddenly
- * grows). The reported value is therefore clamped to be monotonically
- * increasing: it may pause while a newly discovered file catches up, but it
- * never goes backwards.
+ * Prefer transformers.js `progress_total` events: those are pre-seeded with
+ * every expected file's size, so the bar does not jump to 100% after the first
+ * ONNX file finishes while larger siblings are still downloading. Fall back to
+ * per-file `progress` only when totals are unavailable, and rescale `best`
+ * whenever the known byte total grows so the bar can move backwards honestly.
  */
 function makeDownloadTracker(label: string) {
   const files = new Map<string, { loaded: number; total: number }>();
   let best = 0;
-  return (p: { status?: string; file?: string; loaded?: number; total?: number }) => {
+  let lastTotal = 0;
+  let useTotalEvents = false;
+
+  const report = (loaded: number, total: number) => {
+    if (total <= 0) return;
+    if (total > lastTotal && lastTotal > 0 && best > 0) {
+      best *= lastTotal / total;
+    }
+    lastTotal = total;
+    best = Math.max(best, Math.min(1, loaded / total));
+    post({ type: "progress", message: label, value: best });
+  };
+
+  return (p: {
+    status?: string;
+    file?: string;
+    loaded?: number;
+    total?: number;
+    progress?: number;
+  }) => {
+    if (p.status === "progress_total") {
+      useTotalEvents = true;
+      const total = p.total ?? 0;
+      const loaded =
+        total > 0 && typeof p.progress === "number"
+          ? (p.progress / 100) * total
+          : (p.loaded ?? 0);
+      report(loaded, total);
+      return;
+    }
+
+    // Per-file fallback when the library could not pre-seed expected files.
+    if (useTotalEvents) return;
     if (p.status !== "progress" || !p.file || !p.total) return;
     files.set(p.file, { loaded: p.loaded ?? 0, total: p.total });
     let loaded = 0;
@@ -67,9 +99,7 @@ function makeDownloadTracker(label: string) {
       loaded += f.loaded;
       total += f.total;
     }
-    if (total === 0) return;
-    best = Math.max(best, Math.min(1, loaded / total));
-    post({ type: "progress", message: label, value: best });
+    report(loaded, total);
   };
 }
 

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -20,6 +20,7 @@ import {
 } from "@huggingface/transformers";
 import type { Word, WorkerRequest, WorkerResponse } from "@/lib/types";
 import { MODELS, type ModelChoice } from "@/lib/models";
+import { cleanTranscript } from "@/lib/hallucinations";
 
 env.allowLocalModels = false;
 // Serve onnxruntime-web WASM from our own origin (offline friendly).
@@ -296,6 +297,11 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       chunk_length_s: chunkLength,
       stride_length_s: stride,
       return_timestamps: "word",
+      // Anti-repetition: Whisper-base on multi-minute audio often falls into
+      // loops like "little bit of a little bit of a…" near chunk boundaries
+      // or silence. These generation knobs cut that off at decode time.
+      no_repeat_ngram_size: 4,
+      repetition_penalty: 1.15,
       // decoder_input_ids overrides language/task tokens when prompting.
       ...(promptedIds ? { decoder_input_ids: promptedIds } : { language }),
       streamer,
@@ -307,14 +313,14 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       timestamp: [number, number | null];
     }[];
 
-    const words: Word[] = [];
+    const rawWords: Word[] = [];
     for (const c of chunks) {
       const text = c.text.trim();
       if (!text) continue;
       const start = c.timestamp[0] ?? 0;
       const end = c.timestamp[1] ?? Math.min(start + 0.5, duration || start + 0.5);
-      words.push({
-        id: words.length,
+      rawWords.push({
+        id: rawWords.length,
         text,
         start,
         end: Math.max(end, start + 0.02),
@@ -322,6 +328,10 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         deleted: false,
       });
     }
+
+    // Post-process: collapse leftover n-gram loops and drop known hallucination
+    // phrases ("I'm sorry", "thanks for watching", …) that slip past decoding.
+    const words = cleanTranscript(rawWords);
 
     // Best-effort speaker diarization; a failure should not lose the transcript.
     try {

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -13,14 +13,22 @@
 import {
   pipeline,
   AutoProcessor,
+  AutoModel,
   AutoModelForAudioFrameClassification,
   WhisperTextStreamer,
+  Tensor,
   env,
   type AutomaticSpeechRecognitionPipeline,
 } from "@huggingface/transformers";
 import type { Word, WorkerRequest, WorkerResponse } from "@/lib/types";
 import { MODELS, type ModelChoice } from "@/lib/models";
 import { cleanTranscript } from "@/lib/hallucinations";
+import {
+  VAD_FRAME_SIZE,
+  VAD_SAMPLE_RATE,
+  energySpeechFrames,
+  muteLongSilence,
+} from "@/lib/vad";
 
 env.allowLocalModels = false;
 // Serve onnxruntime-web WASM from our own origin (offline friendly).
@@ -29,6 +37,10 @@ if (env.backends?.onnx?.wasm) {
 }
 
 const DIARIZATION_MODEL = "onnx-community/pyannote-segmentation-3.0";
+const VAD_MODEL = "onnx-community/silero-vad";
+/** Contiguous silence longer than this is zeroed before Whisper decoding. */
+const MUTE_MIN_SILENCE_S = 1.5;
+const MUTE_PAD_S = 0.25;
 
 const post = (msg: WorkerResponse, transfer: Transferable[] = []) =>
   (self as unknown as Worker).postMessage(msg, transfer);
@@ -172,6 +184,108 @@ type Diarizer = {
 };
 
 /**
+ * Silero VAD: ~2 MB ONNX model that scores speech probability per 32 ms frame.
+ * Used to mute long silent stretches before Whisper so the decoder does not
+ * invent subtitle-like text over silence. Falls back to energy VAD on failure.
+ */
+type VadModel = {
+  (inputs: {
+    input: InstanceType<typeof Tensor>;
+    sr: InstanceType<typeof Tensor>;
+    state: InstanceType<typeof Tensor>;
+  }): Promise<{
+    output: { data: ArrayLike<number> };
+    stateN: InstanceType<typeof Tensor>;
+  }>;
+};
+
+let vadPromise: Promise<VadModel | null> | null = null;
+function getVad(): Promise<VadModel | null> {
+  if (!vadPromise) {
+    vadPromise = (async () => {
+      try {
+        const model = (await AutoModel.from_pretrained(VAD_MODEL, {
+          // Silero ships as a custom ONNX graph without a transformers config.
+          // @ts-expect-error transformers.js accepts model_type via config override
+          config: { model_type: "custom" },
+          dtype: "fp32",
+        })) as unknown as VadModel;
+        return model;
+      } catch (err) {
+        console.warn("Silero VAD failed to load; using energy-based silence detection.", err);
+        return null;
+      }
+    })();
+    vadPromise.catch(() => {
+      vadPromise = null;
+    });
+  }
+  return vadPromise;
+}
+
+async function speechFramesWithSilero(
+  model: VadModel,
+  audio: Float32Array
+): Promise<boolean[]> {
+  const frameSize = VAD_FRAME_SIZE;
+  const n = Math.ceil(audio.length / frameSize) || 0;
+  const out: boolean[] = new Array(n);
+  const sr = new Tensor("int64", [BigInt(VAD_SAMPLE_RATE)], []);
+  let state = new Tensor("float32", new Float32Array(2 * 1 * 128), [2, 1, 128]);
+  const threshold = 0.5;
+
+  for (let f = 0; f < n; f++) {
+    const start = f * frameSize;
+    const end = Math.min(audio.length, start + frameSize);
+    let frame: Float32Array;
+    if (end - start === frameSize) {
+      // Copy: ORT may retain the input buffer across calls.
+      frame = audio.slice(start, end);
+    } else {
+      // Silero expects exactly 512 samples; zero-pad a trailing partial frame.
+      frame = new Float32Array(frameSize);
+      frame.set(audio.subarray(start, end));
+    }
+    const input = new Tensor("float32", frame, [1, frameSize]);
+    const { output, stateN } = await model({ input, sr, state });
+    state = stateN;
+    out[f] = Number(output.data[0] ?? 0) >= threshold;
+
+    // Yield occasionally so long files don't starve the worker event loop.
+    if (f > 0 && f % 256 === 0) {
+      post({
+        type: "progress",
+        message: "Detecting speech…",
+        value: f / n,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    }
+  }
+  return out;
+}
+
+/**
+ * Mute long silent regions in a copy of `audio`. Prefers Silero VAD; falls
+ * back to energy-based detection. Always preserves length (timestamps stay
+ * aligned). On total failure, returns the original buffer unchanged.
+ */
+async function prepareAudioForAsr(audio: Float32Array): Promise<Float32Array> {
+  try {
+    const vad = await getVad();
+    const frames = vad
+      ? await speechFramesWithSilero(vad, audio)
+      : energySpeechFrames(audio);
+    return muteLongSilence(audio, frames, {
+      minSilenceS: MUTE_MIN_SILENCE_S,
+      padS: MUTE_PAD_S,
+    });
+  } catch (err) {
+    console.warn("Silence muting failed; transcribing original audio.", err);
+    return audio;
+  }
+}
+
+/**
  * Load the diarization model. Started in the background while Whisper is
  * still transcribing, so the (small) speaker model is downloaded, cached,
  * and ready by the time the transcript lands — closing the tab right after
@@ -254,13 +368,22 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
     if (verbatimPrompt && !promptedIds) {
       console.warn("Could not build verbatim prompt tokens; using default decoding.");
     }
-    // Warm up the speaker model in parallel with transcription (errors are
-    // handled when it is awaited later; this avoids an unhandled rejection).
+    // Warm up VAD + speaker models in parallel with ASR load (errors are
+    // handled when awaited later; this avoids unhandled rejections).
+    getVad().catch(() => {});
     getDiarizer().catch(() => {});
+
+    post({ type: "progress", message: "Detecting speech…", value: 0 });
+    // Zero long silent stretches so Whisper does not decode them into
+    // subtitle-like hallucinations. Length is preserved for timestamps.
+    const asrAudio = await prepareAudioForAsr(audio);
+
     post({ type: "progress", message: "Transcribing…", value: 0 });
 
     let partial = "";
-    const chunkLength = 30;
+    // Use 29s instead of 30: transformers.js has a known word-timestamp bug
+    // at exactly chunk_length_s=30 (#1357 / #1358); 29 is the common workaround.
+    const chunkLength = 29;
     const stride = 5;
     const timePrecision =
       // @ts-expect-error feature_extractor config is untyped
@@ -293,7 +416,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       },
     });
 
-    const output = await transcriber(audio, {
+    const output = await transcriber(asrAudio, {
       chunk_length_s: chunkLength,
       stride_length_s: stride,
       return_timestamps: "word",

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -475,9 +475,6 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       reportProgress(0, 0);
     }
 
-    // Re-index after concatenation across segments.
-    for (let i = 0; i < rawWords.length; i++) rawWords[i]!.id = i;
-
     // Post-process: collapse leftover n-gram loops and drop known hallucination
     // phrases ("I'm sorry", "thanks for watching", …) that slip past decoding.
     const words = cleanTranscript(rawWords);

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -27,7 +27,8 @@ import {
   VAD_FRAME_SIZE,
   VAD_SAMPLE_RATE,
   energySpeechFrames,
-  muteLongSilence,
+  speechSegmentsFromFrames,
+  type SpeechSegment,
 } from "@/lib/vad";
 
 env.allowLocalModels = false;
@@ -38,9 +39,9 @@ if (env.backends?.onnx?.wasm) {
 
 const DIARIZATION_MODEL = "onnx-community/pyannote-segmentation-3.0";
 const VAD_MODEL = "onnx-community/silero-vad";
-/** Contiguous silence longer than this is zeroed before Whisper decoding. */
-const MUTE_MIN_SILENCE_S = 1.5;
-const MUTE_PAD_S = 0.25;
+/** Gaps longer than this split speech into separate Whisper jobs. */
+const SPEECH_MAX_GAP_S = 1.5;
+const SPEECH_PAD_S = 0.25;
 
 const post = (msg: WorkerResponse, transfer: Transferable[] = []) =>
   (self as unknown as Worker).postMessage(msg, transfer);
@@ -265,24 +266,27 @@ async function speechFramesWithSilero(
 }
 
 /**
- * Mute long silent regions in a copy of `audio`. Prefers Silero VAD; falls
- * back to energy-based detection. Always preserves length (timestamps stay
- * aligned). On total failure, returns the original buffer unchanged.
+ * Detect speech segments to feed Whisper. Prefers Silero VAD; falls back to
+ * energy-based detection. On total failure, returns one segment covering the
+ * whole buffer so transcription still runs.
  */
-async function prepareAudioForAsr(audio: Float32Array): Promise<Float32Array> {
+async function detectSpeechSegments(audio: Float32Array): Promise<SpeechSegment[]> {
   try {
     const vad = await getVad();
     const frames = vad
       ? await speechFramesWithSilero(vad, audio)
       : energySpeechFrames(audio);
-    return muteLongSilence(audio, frames, {
-      minSilenceS: MUTE_MIN_SILENCE_S,
-      padS: MUTE_PAD_S,
+    const segments = speechSegmentsFromFrames(frames, audio.length, {
+      maxGapS: SPEECH_MAX_GAP_S,
+      padS: SPEECH_PAD_S,
     });
+    if (segments.length > 0) return segments;
+    // VAD found nothing — still try the full clip rather than returning empty.
+    console.warn("VAD found no speech; falling back to full audio.");
   } catch (err) {
-    console.warn("Silence muting failed; transcribing original audio.", err);
-    return audio;
+    console.warn("Speech segmentation failed; falling back to full audio.", err);
   }
+  return [{ startSample: 0, endSample: audio.length }];
 }
 
 /**
@@ -374,9 +378,13 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
     getDiarizer().catch(() => {});
 
     post({ type: "progress", message: "Detecting speech…", value: 0 });
-    // Zero long silent stretches so Whisper does not decode them into
-    // subtitle-like hallucinations. Length is preserved for timestamps.
-    const asrAudio = await prepareAudioForAsr(audio);
+    // Only decode speech — long silence is skipped entirely (not zero-filled),
+    // which is what stops Whisper from inventing subtitle-like text over gaps.
+    const speechSegments = await detectSpeechSegments(audio);
+    const speechSamples = speechSegments.reduce(
+      (n, s) => n + (s.endSample - s.startSample),
+      0
+    );
 
     post({ type: "progress", message: "Transcribing…", value: 0 });
 
@@ -394,32 +402,29 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
     const tokenizer = transcriber.tokenizer as ConstructorParameters<
       typeof WhisperTextStreamer
     >[0];
-    // Chunk start times can jitter around stride boundaries; clamp the
-    // reported transcription progress so it only ever moves forward.
-    let transcribed = 0;
-    const streamer = new WhisperTextStreamer(tokenizer, {
-      skip_prompt: true,
-      time_precision: timePrecision,
-      on_chunk_start: (t: number) => {
-        if (duration > 0) {
-          transcribed = Math.max(transcribed, Math.min(1, t / duration));
-        }
-        post({
-          type: "progress",
-          message: "Transcribing…",
-          value: duration > 0 ? transcribed : null,
-        });
-      },
-      callback_function: (text: string) => {
-        partial += text;
-        post({ type: "partial", text: partial });
-      },
-    });
 
-    const output = await transcriber(asrAudio, {
+    // Progress is weighted by speech-sample coverage so long silent gaps do
+    // not stall the bar, and multi-segment jobs still move smoothly.
+    let speechDone = 0;
+    let transcribed = 0;
+    const reportProgress = (segmentLocalT: number, segmentSamples: number) => {
+      const local = Math.min(
+        segmentSamples,
+        Math.max(0, segmentLocalT * VAD_SAMPLE_RATE)
+      );
+      const overall = speechSamples > 0 ? (speechDone + local) / speechSamples : 1;
+      transcribed = Math.max(transcribed, Math.min(1, overall));
+      post({
+        type: "progress",
+        message: "Transcribing…",
+        value: transcribed,
+      });
+    };
+
+    const asrOptions = {
       chunk_length_s: chunkLength,
       stride_length_s: stride,
-      return_timestamps: "word",
+      return_timestamps: "word" as const,
       // Anti-repetition: Whisper-base on multi-minute audio often falls into
       // loops like "little bit of a little bit of a…" near chunk boundaries
       // or silence. These generation knobs cut that off at decode time.
@@ -427,29 +432,55 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       repetition_penalty: 1.15,
       // decoder_input_ids overrides language/task tokens when prompting.
       ...(promptedIds ? { decoder_input_ids: promptedIds } : { language }),
-      streamer,
-    });
-
-    const result = Array.isArray(output) ? output[0] : output;
-    const chunks = (result.chunks ?? []) as {
-      text: string;
-      timestamp: [number, number | null];
-    }[];
+    };
 
     const rawWords: Word[] = [];
-    for (const c of chunks) {
-      const text = c.text.trim();
-      if (!text) continue;
-      const start = c.timestamp[0] ?? 0;
-      const end = c.timestamp[1] ?? Math.min(start + 0.5, duration || start + 0.5);
-      rawWords.push({
-        id: rawWords.length,
-        text,
-        start,
-        end: Math.max(end, start + 0.02),
-        speaker: 0,
-        deleted: false,
+    for (const seg of speechSegments) {
+      const slice = audio.slice(seg.startSample, seg.endSample);
+      const offsetS = seg.startSample / VAD_SAMPLE_RATE;
+      const segmentSamples = seg.endSample - seg.startSample;
+      const segmentDuration = segmentSamples / VAD_SAMPLE_RATE;
+
+      const streamer = new WhisperTextStreamer(tokenizer, {
+        skip_prompt: true,
+        time_precision: timePrecision,
+        on_chunk_start: (t: number) => {
+          reportProgress(t, segmentSamples);
+        },
+        callback_function: (text: string) => {
+          partial += text;
+          post({ type: "partial", text: partial });
+        },
       });
+
+      const output = await transcriber(slice, { ...asrOptions, streamer });
+      const result = Array.isArray(output) ? output[0] : output;
+      const chunks = (result.chunks ?? []) as {
+        text: string;
+        timestamp: [number, number | null];
+      }[];
+
+      for (const c of chunks) {
+        const text = c.text.trim();
+        if (!text) continue;
+        const start = offsetS + (c.timestamp[0] ?? 0);
+        const rawEnd =
+          offsetS +
+          (c.timestamp[1] ??
+            Math.min((c.timestamp[0] ?? 0) + 0.5, segmentDuration));
+        const end = duration > 0 ? Math.min(rawEnd, duration) : rawEnd;
+        rawWords.push({
+          id: rawWords.length,
+          text,
+          start: duration > 0 ? Math.min(start, duration) : start,
+          end: Math.max(end, start + 0.02),
+          speaker: 0,
+          deleted: false,
+        });
+      }
+
+      speechDone += segmentSamples;
+      reportProgress(0, 0);
     }
 
     // Post-process: collapse leftover n-gram loops and drop known hallucination

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -1,10 +1,10 @@
 /**
  * Transcription worker: runs entirely in the browser.
  *
- * 1. A Whisper-family model (see lib/models.ts) produces a transcript with
- *    per-word timestamps.
- * 2. Pyannote segmentation 3.0 produces speaker segments, which are used to
- *    assign a speaker to each word.
+ * 1. Silero VAD (energy fallback) finds speech segments; silence is skipped.
+ * 2. A Whisper-family model (see lib/models.ts) transcribes each segment with
+ *    per-word timestamps, remapped onto the original timeline.
+ * 3. Pyannote segmentation 3.0 assigns a speaker to each word.
  *
  * Models are fetched from the Hugging Face Hub on first use and cached in the
  * browser Cache Storage; every run after that is fully offline. The ONNX
@@ -186,8 +186,8 @@ type Diarizer = {
 
 /**
  * Silero VAD: ~2 MB ONNX model that scores speech probability per 32 ms frame.
- * Used to mute long silent stretches before Whisper so the decoder does not
- * invent subtitle-like text over silence. Falls back to energy VAD on failure.
+ * Used to find speech segments so Whisper never decodes long silence.
+ * Falls back to energy VAD on failure.
  */
 type VadModel = {
   (inputs: {
@@ -203,23 +203,17 @@ type VadModel = {
 let vadPromise: Promise<VadModel | null> | null = null;
 function getVad(): Promise<VadModel | null> {
   if (!vadPromise) {
-    vadPromise = (async () => {
-      try {
-        const model = (await AutoModel.from_pretrained(VAD_MODEL, {
-          // Silero ships as a custom ONNX graph without a transformers config.
-          // @ts-expect-error transformers.js accepts model_type via config override
-          config: { model_type: "custom" },
-          dtype: "fp32",
-        })) as unknown as VadModel;
-        return model;
-      } catch (err) {
+    vadPromise = AutoModel.from_pretrained(VAD_MODEL, {
+      // Silero ships as a custom ONNX graph without a transformers config.
+      // @ts-expect-error transformers.js accepts model_type via config override
+      config: { model_type: "custom" },
+      dtype: "fp32",
+    })
+      .then((model) => model as unknown as VadModel)
+      .catch((err) => {
         console.warn("Silero VAD failed to load; using energy-based silence detection.", err);
         return null;
-      }
-    })();
-    vadPromise.catch(() => {
-      vadPromise = null;
-    });
+      });
   }
   return vadPromise;
 }
@@ -233,60 +227,87 @@ async function speechFramesWithSilero(
   const out: boolean[] = new Array(n);
   const sr = new Tensor("int64", [BigInt(VAD_SAMPLE_RATE)], []);
   let state = new Tensor("float32", new Float32Array(2 * 1 * 128), [2, 1, 128]);
+  // Reuse one frame buffer across calls — safe because we await each inference.
+  const frameBuf = new Float32Array(frameSize);
   const threshold = 0.5;
 
   for (let f = 0; f < n; f++) {
     const start = f * frameSize;
     const end = Math.min(audio.length, start + frameSize);
-    let frame: Float32Array;
-    if (end - start === frameSize) {
-      // Copy: ORT may retain the input buffer across calls.
-      frame = audio.slice(start, end);
-    } else {
-      // Silero expects exactly 512 samples; zero-pad a trailing partial frame.
-      frame = new Float32Array(frameSize);
-      frame.set(audio.subarray(start, end));
-    }
-    const input = new Tensor("float32", frame, [1, frameSize]);
+    frameBuf.fill(0);
+    frameBuf.set(audio.subarray(start, end));
+    const input = new Tensor("float32", frameBuf, [1, frameSize]);
     const { output, stateN } = await model({ input, sr, state });
     state = stateN;
     out[f] = Number(output.data[0] ?? 0) >= threshold;
 
-    // Yield occasionally so long files don't starve the worker event loop.
-    if (f > 0 && f % 256 === 0) {
-      post({
-        type: "progress",
-        message: "Detecting speech…",
-        value: f / n,
-      });
-      await new Promise((r) => setTimeout(r, 0));
+    if (f > 0 && f % 512 === 0) {
+      post({ type: "progress", message: "Detecting speech…", value: f / n });
     }
   }
   return out;
 }
 
-/**
- * Detect speech segments to feed Whisper. Prefers Silero VAD; falls back to
- * energy-based detection. On total failure, returns one segment covering the
- * whole buffer so transcription still runs.
- */
-async function detectSpeechSegments(audio: Float32Array): Promise<SpeechSegment[]> {
+/** Turn speech-frame flags into segments, with a full-audio fallback. */
+function segmentsOrFull(
+  frames: boolean[],
+  audio: Float32Array
+): SpeechSegment[] {
+  const segments = speechSegmentsFromFrames(frames, audio.length, {
+    maxGapS: SPEECH_MAX_GAP_S,
+    padS: SPEECH_PAD_S,
+  });
+  if (segments.length > 0) return segments;
+  console.warn("VAD found no speech; falling back to full audio.");
+  return [{ startSample: 0, endSample: audio.length }];
+}
+
+async function detectSpeechSegments(
+  audio: Float32Array,
+  vad: VadModel | null
+): Promise<SpeechSegment[]> {
   try {
-    const vad = await getVad();
     const frames = vad
       ? await speechFramesWithSilero(vad, audio)
       : energySpeechFrames(audio);
-    const segments = speechSegmentsFromFrames(frames, audio.length, {
-      maxGapS: SPEECH_MAX_GAP_S,
-      padS: SPEECH_PAD_S,
-    });
-    if (segments.length > 0) return segments;
-    // VAD found nothing — still try the full clip rather than returning empty.
-    console.warn("VAD found no speech; falling back to full audio.");
+    return segmentsOrFull(frames, audio);
   } catch (err) {
     console.warn("Speech segmentation failed; falling back to full audio.", err);
+    return [{ startSample: 0, endSample: audio.length }];
   }
-  return [{ startSample: 0, endSample: audio.length }];
+}
+
+type AsrChunk = { text: string; timestamp: [number, number | null] };
+
+/** Map Whisper word chunks from a segment onto the original media timeline. */
+function wordsFromChunks(
+  chunks: AsrChunk[],
+  offsetS: number,
+  segmentDuration: number,
+  mediaDuration: number
+): Word[] {
+  const words: Word[] = [];
+  for (const c of chunks) {
+    const text = c.text.trim();
+    if (!text) continue;
+    const localStart = c.timestamp[0] ?? 0;
+    const localEnd = c.timestamp[1] ?? Math.min(localStart + 0.5, segmentDuration);
+    let start = offsetS + localStart;
+    let end = offsetS + localEnd;
+    if (mediaDuration > 0) {
+      start = Math.min(start, mediaDuration);
+      end = Math.min(end, mediaDuration);
+    }
+    words.push({
+      id: words.length,
+      text,
+      start,
+      end: Math.max(end, start + 0.02),
+      speaker: 0,
+      deleted: false,
+    });
+  }
+  return words;
 }
 
 /**
@@ -363,7 +384,13 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
   const { audio, duration, model, language } = event.data;
   try {
     const choice = model ?? "fast";
-    const transcriber = await getAsr(choice);
+
+    // Overlap Whisper + Silero downloads; diarizer warms in the background.
+    getDiarizer().catch(() => {});
+    const [transcriber, vad] = await Promise.all([getAsr(choice), getVad()]);
+
+    post({ type: "progress", message: "Detecting speech…", value: 0 });
+    const speechSegments = await detectSpeechSegments(audio, vad);
 
     const { verbatimPrompt } = MODELS[choice];
     const promptedIds = verbatimPrompt
@@ -372,15 +399,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
     if (verbatimPrompt && !promptedIds) {
       console.warn("Could not build verbatim prompt tokens; using default decoding.");
     }
-    // Warm up VAD + speaker models in parallel with ASR load (errors are
-    // handled when awaited later; this avoids unhandled rejections).
-    getVad().catch(() => {});
-    getDiarizer().catch(() => {});
 
-    post({ type: "progress", message: "Detecting speech…", value: 0 });
-    // Only decode speech — long silence is skipped entirely (not zero-filled),
-    // which is what stops Whisper from inventing subtitle-like text over gaps.
-    const speechSegments = await detectSpeechSegments(audio);
     const speechSamples = speechSegments.reduce(
       (n, s) => n + (s.endSample - s.startSample),
       0
@@ -403,8 +422,6 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       typeof WhisperTextStreamer
     >[0];
 
-    // Progress is weighted by speech-sample coverage so long silent gaps do
-    // not stall the bar, and multi-segment jobs still move smoothly.
     let speechDone = 0;
     let transcribed = 0;
     const reportProgress = (segmentLocalT: number, segmentSamples: number) => {
@@ -412,13 +429,11 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         segmentSamples,
         Math.max(0, segmentLocalT * VAD_SAMPLE_RATE)
       );
-      const overall = speechSamples > 0 ? (speechDone + local) / speechSamples : 1;
-      transcribed = Math.max(transcribed, Math.min(1, overall));
-      post({
-        type: "progress",
-        message: "Transcribing…",
-        value: transcribed,
-      });
+      transcribed = Math.max(
+        transcribed,
+        Math.min(1, speechSamples > 0 ? (speechDone + local) / speechSamples : 1)
+      );
+      post({ type: "progress", message: "Transcribing…", value: transcribed });
     };
 
     const asrOptions = {
@@ -430,23 +445,21 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       // or silence. These generation knobs cut that off at decode time.
       no_repeat_ngram_size: 4,
       repetition_penalty: 1.15,
-      // decoder_input_ids overrides language/task tokens when prompting.
       ...(promptedIds ? { decoder_input_ids: promptedIds } : { language }),
     };
 
     const rawWords: Word[] = [];
     for (const seg of speechSegments) {
-      const slice = audio.slice(seg.startSample, seg.endSample);
-      const offsetS = seg.startSample / VAD_SAMPLE_RATE;
       const segmentSamples = seg.endSample - seg.startSample;
       const segmentDuration = segmentSamples / VAD_SAMPLE_RATE;
+      const offsetS = seg.startSample / VAD_SAMPLE_RATE;
+      // subarray avoids copying; Whisper/ORT owns the samples for this await.
+      const slice = audio.subarray(seg.startSample, seg.endSample);
 
       const streamer = new WhisperTextStreamer(tokenizer, {
         skip_prompt: true,
         time_precision: timePrecision,
-        on_chunk_start: (t: number) => {
-          reportProgress(t, segmentSamples);
-        },
+        on_chunk_start: (t: number) => reportProgress(t, segmentSamples),
         callback_function: (text: string) => {
           partial += text;
           post({ type: "partial", text: partial });
@@ -455,33 +468,15 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
       const output = await transcriber(slice, { ...asrOptions, streamer });
       const result = Array.isArray(output) ? output[0] : output;
-      const chunks = (result.chunks ?? []) as {
-        text: string;
-        timestamp: [number, number | null];
-      }[];
-
-      for (const c of chunks) {
-        const text = c.text.trim();
-        if (!text) continue;
-        const start = offsetS + (c.timestamp[0] ?? 0);
-        const rawEnd =
-          offsetS +
-          (c.timestamp[1] ??
-            Math.min((c.timestamp[0] ?? 0) + 0.5, segmentDuration));
-        const end = duration > 0 ? Math.min(rawEnd, duration) : rawEnd;
-        rawWords.push({
-          id: rawWords.length,
-          text,
-          start: duration > 0 ? Math.min(start, duration) : start,
-          end: Math.max(end, start + 0.02),
-          speaker: 0,
-          deleted: false,
-        });
-      }
+      const chunks = (result.chunks ?? []) as AsrChunk[];
+      rawWords.push(...wordsFromChunks(chunks, offsetS, segmentDuration, duration));
 
       speechDone += segmentSamples;
       reportProgress(0, 0);
     }
+
+    // Re-index after concatenation across segments.
+    for (let i = 0; i < rawWords.length; i++) rawWords[i]!.id = i;
 
     // Post-process: collapse leftover n-gram loops and drop known hallucination
     // phrases ("I'm sorry", "thanks for watching", …) that slip past decoding.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#13](https://github.com/wassgha/rescript/issues/13): after a few minutes of correct transcription, Whisper-base often falls into a hallucination loop — typically `"I'm sorry"` followed by something like `"ittle bit of a little bit of a little bit…"`.

Also adds **Whisper Small** as an optional, more accurate model selectable from the homepage before upload.

<img width="682" height="268" alt="Screenshot 2026-07-27 at 11 37 24 AM" src="https://github.com/user-attachments/assets/b26ee1ca-f141-4a48-a7ae-b1232a32111c" />


## Approach

### Hallucination mitigations

1. **Silence skip** (`lib/vad.ts`) — Silero VAD finds speech segments; only those slices are sent to Whisper. Timestamps are remapped onto the original timeline. Falls back to energy-based detection if Silero fails. Whisper + Silero downloads overlap.
2. **Chunk length 29** — workaround for the transformers.js word-timestamp bug at exactly `chunk_length_s: 30`.
3. **Decode-time** — `no_repeat_ngram_size: 4` and `repetition_penalty: 1.15`.
4. **Post-process** (`lib/hallucinations.ts`) — collapse repeating n-grams, strip known hallucination phrases, trim degenerate tails.

### Model selector

- Choices: **Whisper Base** (~200 MB) and **Whisper Small** (~600 MB)
- Compact dropdown on the upload screen (opens above the trigger)
- Both models keep the filler-bias prompt so um/uh remain editable

## Testing

- `scripts/vad-test.ts`, `scripts/hallucination-test.ts`
- `npm run lint` and `npm run build` pass

## Follow-up

Whisper Small should further reduce long-form loops; Base remains the default for faster first runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

