### PR TITLE
Auto-save projects to IndexedDB with recent list

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -14,14 +14,17 @@ import ExportDialog from "./ExportDialog";
 export default function Editor() {
   const status = useEditorStore((s) => s.status);
   const videoFile = useEditorStore((s) => s.videoFile);
+  const skipTranscription = useEditorStore((s) => s.skipTranscription);
   const loadVideo = useEditorStore((s) => s.loadVideo);
   const { transcribe } = useTranscriber();
 
-  // Processing pipeline: load ffmpeg -> extract audio -> transcribe.
+  // Processing pipeline: load ffmpeg -> extract audio -> (maybe) transcribe.
+  // Restored projects already have words; they only need PCM for the waveform.
   const startedFor = useRef<File | null>(null);
   useEffect(() => {
     if (!videoFile || startedFor.current === videoFile) return;
     startedFor.current = videoFile;
+    const restoreOnly = useEditorStore.getState().skipTranscription;
     (async () => {
       const s = useEditorStore.getState();
       try {
@@ -30,13 +33,18 @@ export default function Editor() {
         s.setProgress({ message: "Extracting audio…", value: null });
         const audio = await extractAudio(videoFile);
         s.setAudio(audio);
-        transcribe(audio, audio.length / 16000);
+        if (restoreOnly) {
+          s.setStatus("ready");
+          s.setProgress({ message: "", value: null });
+        } else {
+          transcribe(audio, audio.length / 16000);
+        }
       } catch (err) {
         console.error("Processing pipeline failed:", err);
         s.setError(err instanceof Error ? err.message : "Failed to process this file.");
       }
     })();
-  }, [videoFile, transcribe]);
+  }, [videoFile, skipTranscription, transcribe]);
 
   // Global shortcuts: space = play/pause, ⌘Z / ⇧⌘Z = undo / redo.
   useEffect(() => {
@@ -57,6 +65,22 @@ export default function Editor() {
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  // Flush pending autosave when the tab hides or unloads.
+  useEffect(() => {
+    const flush = () => {
+      void import("@/lib/autosave").then((m) => m.flushProjectAutosave());
+    };
+    const onVis = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", onVis);
+    };
   }, []);
 
   return (

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import {
   AudioLines,
@@ -11,12 +11,20 @@ import {
   Music,
   Scissors,
   ShieldAlert,
+  Trash2,
   Type,
 } from "lucide-react";
 import logo from "@/assets/logo.png";
 import ModelSelector from "./ModelSelector";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
 import { detectMediaKind, MEDIA_ACCEPT } from "@/lib/media";
+import { formatTime } from "@/lib/edits";
+import {
+  formatRelativeTime,
+  listProjects,
+  type ProjectMeta,
+} from "@/lib/projects";
+import { useEditorStore } from "@/lib/store";
 
 // The three media cards that stand in for the upload icon. Each carries its
 // resting transform plus the fanned-out one, applied either on hover (via the
@@ -70,14 +78,109 @@ function MediaCards({ dragging }: { dragging: boolean }) {
   );
 }
 
+function RecentProjects({
+  projects,
+  busyId,
+  onOpen,
+  onRemove,
+}: {
+  projects: ProjectMeta[];
+  busyId: string | null;
+  onOpen: (id: string) => void;
+  onRemove: (id: string) => void;
+}) {
+  if (projects.length === 0) return null;
+  return (
+    <div className="mt-6">
+      <p className="mb-2 text-[11px] font-medium tracking-wide text-zinc-400">
+        Recent
+      </p>
+      <ul className="divide-y divide-zinc-100 overflow-hidden rounded-xl border border-zinc-200 bg-white/80">
+        {projects.map((p) => {
+          const KindIcon = p.mediaKind === "audio" ? AudioLines : Film;
+          const opening = busyId === p.id;
+          return (
+            <li key={p.id}>
+              <div className="flex items-center gap-1 pr-1">
+                <button
+                  type="button"
+                  disabled={busyId !== null}
+                  onClick={() => onOpen(p.id)}
+                  className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5 text-left transition hover:bg-zinc-50 disabled:opacity-60"
+                >
+                  <KindIcon size={16} className="shrink-0 text-zinc-400" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[13px] font-medium text-zinc-800">
+                      {p.name}
+                    </span>
+                    <span className="mt-0.5 block text-[11px] text-zinc-400">
+                      {formatRelativeTime(p.updatedAt)}
+                      {p.duration > 0 ? ` · ${formatTime(p.duration)}` : ""}
+                      {` · ${p.mediaKind}`}
+                    </span>
+                  </span>
+                  {opening && (
+                    <Loader2 size={14} className="shrink-0 animate-spin text-zinc-400" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  title="Remove from recent"
+                  disabled={busyId !== null}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemove(p.id);
+                  }}
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700 disabled:opacity-40"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 export default function UploadScreen({ onFile }: { onFile: (file: File) => void }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
+  const [projects, setProjects] = useState<ProjectMeta[]>([]);
+  const [busyId, setBusyId] = useState<string | null>(null);
   // The pipeline needs SharedArrayBuffer, which on static hosts only appears
   // after the COI service worker reloads the page. Accepting a file before then
   // would fail immediately and lose the file to that reload.
   const isolation = useCrossOriginIsolated();
   const ready = isolation === "ready";
+  const openProject = useEditorStore((s) => s.openProject);
+  const removeProject = useEditorStore((s) => s.removeProject);
+
+  const refreshProjects = useCallback(async () => {
+    try {
+      setProjects(await listProjects());
+    } catch (err) {
+      console.warn("Failed to list saved projects.", err);
+      setProjects([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    // IndexedDB is an external store; load once on mount for the recent list.
+    void listProjects()
+      .then((rows) => {
+        if (!cancelled) setProjects(rows);
+      })
+      .catch((err) => {
+        console.warn("Failed to list saved projects.", err);
+        if (!cancelled) setProjects([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleFiles = useCallback(
     (files: FileList | null) => {
@@ -91,6 +194,36 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
       onFile(file);
     },
     [onFile, ready]
+  );
+
+  const handleOpen = useCallback(
+    async (id: string) => {
+      if (!ready) return;
+      setBusyId(id);
+      try {
+        await openProject(id);
+      } catch (err) {
+        console.error(err);
+        alert(err instanceof Error ? err.message : "Could not open that project.");
+        await refreshProjects();
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [openProject, ready, refreshProjects]
+  );
+
+  const handleRemove = useCallback(
+    async (id: string) => {
+      try {
+        await removeProject(id);
+        await refreshProjects();
+      } catch (err) {
+        console.error(err);
+        alert("Could not remove that project.");
+      }
+    },
+    [removeProject, refreshProjects]
   );
 
   return (
@@ -187,6 +320,15 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
             onChange={(e) => handleFiles(e.target.files)}
           />
         </div>
+
+        {ready && (
+          <RecentProjects
+            projects={projects}
+            busyId={busyId}
+            onOpen={handleOpen}
+            onRemove={handleRemove}
+          />
+        )}
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
           {[

--- a/lib/autosave.ts
+++ b/lib/autosave.ts
@@ -1,0 +1,77 @@
+/**
+ * Debounced autosave of the current editor project into IndexedDB.
+ */
+
+import { useEditorStore } from "./store";
+import { getProject, putProject } from "./projects";
+
+const DEBOUNCE_MS = 500;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let inflight: Promise<void> | null = null;
+let queued = false;
+
+export function scheduleProjectAutosave() {
+  if (typeof window === "undefined") return;
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => {
+    timer = null;
+    void flushProjectAutosave();
+  }, DEBOUNCE_MS);
+}
+
+/** Flush any pending debounce and wait for the write to finish. */
+export async function flushProjectAutosave(): Promise<void> {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  if (inflight) {
+    queued = true;
+    await inflight;
+    if (queued) await flushProjectAutosave();
+    return;
+  }
+
+  inflight = writeSnapshot();
+  try {
+    await inflight;
+  } finally {
+    inflight = null;
+  }
+  if (queued) {
+    queued = false;
+    await flushProjectAutosave();
+  }
+}
+
+async function writeSnapshot() {
+  const s = useEditorStore.getState();
+  if (s.status !== "ready") return;
+  if (!s.videoFile || !s.mediaKind || s.words.length === 0) return;
+
+  try {
+    let createdAt: number | undefined;
+    if (s.projectId) {
+      const existing = await getProject(s.projectId);
+      createdAt = existing?.createdAt;
+    }
+    const id = await putProject({
+      id: s.projectId ?? undefined,
+      name: s.videoFile.name,
+      mediaKind: s.mediaKind,
+      duration: s.duration,
+      model: s.model,
+      words: s.words,
+      showDeleted: s.showDeleted,
+      media: s.videoFile,
+      mediaType: s.videoFile.type,
+      createdAt,
+    });
+    if (useEditorStore.getState().projectId !== id) {
+      useEditorStore.setState({ projectId: id });
+    }
+  } catch (err) {
+    console.warn("Failed to autosave project.", err);
+  }
+}

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,0 +1,190 @@
+/**
+ * IndexedDB persistence for Rescript projects.
+ *
+ * Stores the original media blob + transcript words so a refresh can restore
+ * the editor without re-uploading or re-transcribing. Caps at MAX_PROJECTS
+ * (oldest by updatedAt are pruned).
+ */
+
+import type { ModelChoice } from "./models";
+import type { MediaKind } from "./media";
+import type { Word } from "./types";
+
+const DB_NAME = "rescript-projects";
+const DB_VERSION = 1;
+const STORE = "projects";
+export const MAX_PROJECTS = 10;
+
+export interface ProjectMeta {
+  id: string;
+  name: string;
+  mediaKind: MediaKind;
+  duration: number;
+  model: ModelChoice;
+  updatedAt: number;
+  createdAt: number;
+}
+
+export interface ProjectRecord extends ProjectMeta {
+  words: Word[];
+  showDeleted: boolean;
+  /** Original media bytes. */
+  media: Blob;
+  /** MIME type used when reconstructing a File. */
+  mediaType: string;
+}
+
+export type ProjectWrite = Omit<ProjectRecord, "id" | "createdAt" | "updatedAt"> & {
+  id?: string;
+  createdAt?: number;
+};
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB is not available."));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { keyPath: "id" });
+        store.createIndex("updatedAt", "updatedAt", { unique: false });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("Failed to open projects DB."));
+  });
+}
+
+function idbReq<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("IndexedDB request failed."));
+  });
+}
+
+function txDone(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction failed."));
+    tx.onabort = () => reject(tx.error ?? new Error("IndexedDB transaction aborted."));
+  });
+}
+
+/** List projects newest-first (metadata only — no media/words payloads). */
+export async function listProjects(): Promise<ProjectMeta[]> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(STORE, "readonly");
+    const store = tx.objectStore(STORE);
+    const rows = await idbReq(store.getAll() as IDBRequest<ProjectRecord[]>);
+    await txDone(tx);
+    return rows
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        mediaKind: r.mediaKind,
+        duration: r.duration,
+        model: r.model,
+        updatedAt: r.updatedAt,
+        createdAt: r.createdAt,
+      }))
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  } finally {
+    db.close();
+  }
+}
+
+export async function getProject(id: string): Promise<ProjectRecord | null> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(STORE, "readonly");
+    const row = await idbReq(
+      tx.objectStore(STORE).get(id) as IDBRequest<ProjectRecord | undefined>
+    );
+    await txDone(tx);
+    return row ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+/** Insert or replace a project, then prune to MAX_PROJECTS. Returns the id. */
+export async function putProject(input: ProjectWrite): Promise<string> {
+  const now = Date.now();
+  const record: ProjectRecord = {
+    id: input.id ?? crypto.randomUUID(),
+    name: input.name,
+    mediaKind: input.mediaKind,
+    duration: input.duration,
+    model: input.model,
+    words: input.words,
+    showDeleted: input.showDeleted,
+    media: input.media,
+    mediaType: input.mediaType,
+    createdAt: input.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  const db = await openDb();
+  try {
+    const tx = db.transaction(STORE, "readwrite");
+    const store = tx.objectStore(STORE);
+    store.put(record);
+
+    // Prune oldest beyond the cap (never delete the record we just wrote).
+    const all = await idbReq(store.getAll() as IDBRequest<ProjectRecord[]>);
+    if (all.length > MAX_PROJECTS) {
+      const sorted = [...all].sort((a, b) => a.updatedAt - b.updatedAt);
+      let excess = all.length - MAX_PROJECTS;
+      for (const row of sorted) {
+        if (excess <= 0) break;
+        if (row.id === record.id) continue;
+        store.delete(row.id);
+        excess--;
+      }
+    }
+
+    await txDone(tx);
+    return record.id;
+  } finally {
+    db.close();
+  }
+}
+
+export async function deleteProject(id: string): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).delete(id);
+    await txDone(tx);
+  } finally {
+    db.close();
+  }
+}
+
+/** Reconstruct a File from a stored project for preview/export. */
+export function fileFromProject(project: ProjectRecord): File {
+  return new File([project.media], project.name, {
+    type: project.mediaType || project.media.type || undefined,
+    lastModified: project.updatedAt,
+  });
+}
+
+/** Compact relative time for the recent list (e.g. "just now", "3h ago"). */
+export function formatRelativeTime(ts: number, now = Date.now()): string {
+  const sec = Math.max(0, Math.round((now - ts) / 1000));
+  if (sec < 45) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 48) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 14) return `${day}d ago`;
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -5,6 +5,12 @@ import type { EditorStatus, ProgressInfo, Word } from "./types";
 import type { ModelChoice } from "./models";
 import { loadModelPreference, saveModelPreference } from "./models";
 import { detectMediaKind, type MediaKind } from "./media";
+import {
+  deleteProject,
+  fileFromProject,
+  getProject,
+  type ProjectMeta,
+} from "./projects";
 
 interface EditorState {
   // Media
@@ -17,6 +23,13 @@ interface EditorState {
   audio: Float32Array | null;
   /** Transcription model selected on the upload screen. */
   model: ModelChoice;
+  /** IndexedDB project id when this session is persisted; null for a fresh upload mid-pipeline. */
+  projectId: string | null;
+  /**
+   * When true, Editor extracts audio for the waveform but skips Whisper
+   * (restored projects already have words).
+   */
+  skipTranscription: boolean;
 
   // Pipeline status
   status: EditorStatus;
@@ -42,6 +55,10 @@ interface EditorState {
 
   // Actions
   loadVideo: (file: File) => void;
+  /** Restore a saved project from IndexedDB (no re-transcription). */
+  openProject: (id: string) => Promise<void>;
+  /** Delete a saved project; if it is the active one, resets to the home screen. */
+  removeProject: (id: string) => Promise<void>;
   setModel: (m: ModelChoice) => void;
   setDuration: (d: number) => void;
   setAudio: (a: Float32Array) => void;
@@ -65,6 +82,11 @@ interface EditorState {
   reset: () => void;
 }
 
+function bumpAutosave() {
+  // Dynamic import avoids a circular dependency with lib/autosave.ts.
+  void import("./autosave").then((m) => m.scheduleProjectAutosave());
+}
+
 export const useEditorStore = create<EditorState>((set, get) => ({
   videoFile: null,
   mediaUrl: null,
@@ -72,6 +94,8 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   duration: 0,
   audio: null,
   model: "base",
+  projectId: null,
+  skipTranscription: false,
 
   status: "idle",
   progress: { message: "", value: null },
@@ -99,6 +123,8 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       videoFile: file,
       mediaUrl: URL.createObjectURL(file),
       mediaKind: kind,
+      projectId: null,
+      skipTranscription: false,
       status: "preparing",
       progress: { message: "Loading media engine…", value: null },
       words: [],
@@ -108,19 +134,68 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       error: null,
       currentTime: 0,
       exportUrl: null,
+      audio: null,
+      duration: 0,
     });
   },
+
+  openProject: async (id) => {
+    const record = await getProject(id);
+    if (!record) throw new Error("That project is no longer saved.");
+    const file = fileFromProject(record);
+    const prev = get().mediaUrl;
+    if (prev) URL.revokeObjectURL(prev);
+    set({
+      videoFile: file,
+      mediaUrl: URL.createObjectURL(file),
+      mediaKind: record.mediaKind,
+      duration: record.duration,
+      model: record.model,
+      projectId: record.id,
+      skipTranscription: true,
+      status: "preparing",
+      progress: { message: "Loading media engine…", value: null },
+      words: record.words,
+      showDeleted: record.showDeleted,
+      past: [],
+      future: [],
+      partialText: "",
+      error: null,
+      currentTime: 0,
+      playing: false,
+      exportUrl: null,
+      exportOpen: false,
+      audio: null,
+    });
+  },
+
+  removeProject: async (id) => {
+    await deleteProject(id);
+    if (get().projectId === id) {
+      get().reset();
+    }
+  },
+
   setModel: (model) => {
     saveModelPreference(model);
     set({ model });
   },
-  setDuration: (duration) => set({ duration }),
+  setDuration: (duration) => {
+    set({ duration });
+    if (get().status === "ready") bumpAutosave();
+  },
   setAudio: (audio) => set({ audio }),
-  setStatus: (status) => set({ status }),
+  setStatus: (status) => {
+    set({ status });
+    if (status === "ready") bumpAutosave();
+  },
   setProgress: (progress) => set({ progress }),
   setPartialText: (partialText) => set({ partialText }),
   setError: (message) => set({ status: "error", error: message }),
-  setWords: (words) => set({ words, past: [], future: [] }),
+  setWords: (words) => {
+    set({ words, past: [], future: [] });
+    if (get().status === "ready") bumpAutosave();
+  },
 
   deleteWords: (ids) => {
     if (ids.length === 0) return;
@@ -131,6 +206,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       future: [],
       words: words.map((w) => (idSet.has(w.id) && !w.deleted ? { ...w, deleted: true } : w)),
     });
+    bumpAutosave();
   },
   restoreWords: (ids) => {
     if (ids.length === 0) return;
@@ -141,6 +217,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       future: [],
       words: words.map((w) => (idSet.has(w.id) && w.deleted ? { ...w, deleted: false } : w)),
     });
+    bumpAutosave();
   },
   correctWords: (ids, text) => {
     const { words, past } = get();
@@ -188,6 +265,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       future: [],
       words: [...words.slice(0, from), ...replacement, ...words.slice(to + 1)],
     });
+    bumpAutosave();
   },
   undo: () => {
     const { past, future, words } = get();
@@ -197,6 +275,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       past: past.slice(0, -1),
       future: [words, ...future],
     });
+    bumpAutosave();
   },
   redo: () => {
     const { past, future, words } = get();
@@ -206,8 +285,12 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       future: future.slice(1),
       past: [...past, words],
     });
+    bumpAutosave();
   },
-  toggleShowDeleted: () => set((s) => ({ showDeleted: !s.showDeleted })),
+  toggleShowDeleted: () => {
+    set((s) => ({ showDeleted: !s.showDeleted }));
+    bumpAutosave();
+  },
 
   setCurrentTime: (currentTime) => set({ currentTime }),
   setPlaying: (playing) => set({ playing }),
@@ -225,6 +308,8 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       mediaKind: null,
       duration: 0,
       audio: null,
+      projectId: null,
+      skipTranscription: false,
       status: "idle",
       progress: { message: "", value: null },
       partialText: "",
@@ -247,3 +332,5 @@ export function hydrateModelPreference() {
     useEditorStore.setState({ model: stored });
   }
 }
+
+export type { ProjectMeta };

--- a/scripts/projects-test.ts
+++ b/scripts/projects-test.ts
@@ -1,0 +1,14 @@
+import { formatRelativeTime } from "../lib/projects";
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const now = Date.parse("2026-07-27T12:00:00Z");
+
+assert(formatRelativeTime(now - 10_000, now) === "just now", "just now");
+assert(formatRelativeTime(now - 5 * 60_000, now) === "5m ago", "minutes");
+assert(formatRelativeTime(now - 3 * 3600_000, now) === "3h ago", "hours");
+assert(formatRelativeTime(now - 3 * 86400_000, now) === "3d ago", "days");
+
+console.log("ALL PROJECT HELPER TESTS PASSED");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Projects auto-save locally so closing or refreshing the tab does not lose transcript edits. A **Recent** list on the home screen opens saved work in one click.

<img width="697" height="545" alt="Screenshot 2026-07-27 at 11 57 06 AM" src="https://github.com/user-attachments/assets/71a5fa89-c168-452e-bf00-69827b1dbc6e" />


## Approach

- **IndexedDB** (`lib/projects.ts`) stores media blob + words + metadata (name, duration, kind, model). Cap of **10** projects; oldest pruned.
- **Debounced autosave** (`lib/autosave.ts`) after transcription completes and after each edit (delete/restore/correct/undo/redo/show-deleted). Flushes on `pagehide` / tab hide.
- **Restore** rebuilds a `File` from the blob, skips Whisper, and only re-extracts PCM for the waveform.
- **Home UI** — Recent rows under the drop zone with relative time, duration, kind, open, and delete.

## Out of scope (v1)

Downloadable project files, undo-history persistence, storing extracted PCM.

## Testing

- `scripts/projects-test.ts` — relative time helper
- `npm run lint` / `npm run build` pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

