### PR TITLE
Add GitHub repo links on upload and editor

### DIFF
--- a/components/GitHubLink.tsx
+++ b/components/GitHubLink.tsx
@@ -1,6 +1,18 @@
-import { Github } from "lucide-react";
-
 export const GITHUB_REPO_URL = "https://github.com/wassgha/rescript";
+
+function GitHubIcon({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.269 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.295 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
+    </svg>
+  );
+}
 
 /** Compact link to the public repo — icon for the editor bar, labeled for the upload footer. */
 export default function GitHubLink({
@@ -16,7 +28,7 @@ export default function GitHubLink({
         rel="noopener noreferrer"
         className="inline-flex items-center gap-1 text-xs text-zinc-400 transition hover:text-zinc-600"
       >
-        <Github size={12} aria-hidden />
+        <GitHubIcon size={12} />
         GitHub
       </a>
     );
@@ -31,7 +43,7 @@ export default function GitHubLink({
       aria-label="GitHub repository"
       className="flex h-8 w-8 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-800"
     >
-      <Github size={16} aria-hidden />
+      <GitHubIcon size={16} />
     </a>
   );
 }

--- a/components/GitHubLink.tsx
+++ b/components/GitHubLink.tsx
@@ -1,0 +1,37 @@
+import { Github } from "lucide-react";
+
+export const GITHUB_REPO_URL = "https://github.com/wassgha/rescript";
+
+/** Compact link to the public repo — icon for the editor bar, labeled for the upload footer. */
+export default function GitHubLink({
+  variant = "icon",
+}: {
+  variant?: "icon" | "text";
+}) {
+  if (variant === "text") {
+    return (
+      <a
+        href={GITHUB_REPO_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-xs text-zinc-400 transition hover:text-zinc-600"
+      >
+        <Github size={12} aria-hidden />
+        GitHub
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={GITHUB_REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      title="GitHub"
+      aria-label="GitHub repository"
+      className="flex h-8 w-8 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-800"
+    >
+      <Github size={16} aria-hidden />
+    </a>
+  );
+}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -4,6 +4,7 @@ import { Download, Redo2, Undo2 } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import Image from "next/image";
 import logo from "@/assets/logo.png";
+import GitHubLink from "./GitHubLink";
 
 export default function TopBar() {
   const videoFile = useEditorStore((s) => s.videoFile);
@@ -42,6 +43,7 @@ export default function TopBar() {
       )}
 
       <div className="ml-auto flex items-center gap-1">
+        <GitHubLink />
         <button
           onClick={undo}
           disabled={!canUndo}

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -15,6 +15,7 @@ import {
   Type,
 } from "lucide-react";
 import logo from "@/assets/logo.png";
+import GitHubLink from "./GitHubLink";
 import ModelSelector from "./ModelSelector";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
 import { detectMediaKind, MEDIA_ACCEPT } from "@/lib/media";
@@ -344,10 +345,13 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
           ))}
         </div>
 
-        <p className="mt-6 flex items-center justify-center gap-1.5 text-center text-xs text-zinc-400">
-          <Lock size={12} />
-          No uploads, no accounts — your media never leaves this device.
-        </p>
+        <div className="mt-6 flex flex-col items-center gap-2">
+          <p className="flex items-center justify-center gap-1.5 text-center text-xs text-zinc-400">
+            <Lock size={12} />
+            No uploads, no accounts — your media never leaves this device.
+          </p>
+          <GitHubLink variant="text" />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small link to https://github.com/wassgha/rescript so the project is discoverable from the app chrome:

- **Upload page** — labeled GitHub link under the privacy footer line
- **Editor** — icon button in the top bar (left of undo/redo)

Shared via `components/GitHubLink.tsx` with an inline SVG mark (lucide-react no longer ships brand icons).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

