### PR TITLE
Fix upload page scrolling on mobile

### DIFF
--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -228,8 +228,11 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
   );
 
   return (
-    <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-zinc-50 to-neutral-50/50 p-6">
-      <div className="w-full max-w-xl">
+    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain bg-gradient-to-b from-zinc-50 to-neutral-50/50">
+      {/* min-h-full + items-center centers when content fits; the outer
+          overflow-y-auto still lets short viewports (mobile) scroll the top. */}
+      <div className="flex min-h-full items-center justify-center p-6">
+        <div className="w-full max-w-xl">
         <div className="mb-6 flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center">
             <Image
@@ -352,6 +355,7 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
           </p>
           <GitHubLink variant="text" />
         </div>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The editor shell is `h-dvh` + `overflow-hidden`. The upload screen centered its content with `flex-1` and no scroll container, so on short mobile viewports the privacy line / GitHub link / feature cards were clipped and unreachable.

## Fix

`UploadScreen` now scrolls with `min-h-0 flex-1 overflow-y-auto`, and an inner `min-h-full` flex center keeps the layout vertically centered when everything fits.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

