### PR TITLE
Import your own SRT/VTT/JSON transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ audio track.
 1. **Extract** — ffmpeg.wasm decodes the audio track to mono 16 kHz PCM.
 2. **Transcribe** — Whisper runs in a Web Worker with `return_timestamps: "word"`,
    streaming text as it goes; pyannote assigns a speaker to every word.
-   Choose **Whisper Base** or **Whisper Small** on the homepage.
-   Alternatively, **import an SRT / VTT / JSON** transcript and skip AI entirely.
+   Choose **Whisper Base**, **Whisper Small**, or **Import transcript**
+   (SRT / VTT / JSON) on the homepage.
 3. **Edit** — deleting words produces "cut ranges" of the original media. The
    preview player skips them in real time and the timeline shows them in red.
    **Remove fillers** cuts every detected "um" / "uh" / etc. in one click.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the media. Export the final cut — without your file ever leaving your device.
 
 - 🔒 **Private by design** — no server, no auth, no uploads; all media processing happens on-device
 - 📝 **Word-level editing** — select words, press ⌫, the cut follows the text
+- 📥 **Import your own transcript** — skip Whisper and edit with an SRT, VTT, or JSON caption file
 - 🧹 **Filler removal** — one-click cut of "um", "uh", and similar fillers
 - 🗣️ **Speaker diarization** — the transcript is grouped by speaker
 - 🎬 **Timeline** — waveform, word labels, cut regions, playhead, zoom
@@ -62,6 +63,7 @@ audio track.
 2. **Transcribe** — Whisper runs in a Web Worker with `return_timestamps: "word"`,
    streaming text as it goes; pyannote assigns a speaker to every word.
    Choose **Whisper Base** or **Whisper Small** on the homepage.
+   Alternatively, **import an SRT / VTT / JSON** transcript and skip AI entirely.
 3. **Edit** — deleting words produces "cut ranges" of the original media. The
    preview player skips them in real time and the timeline shows them in red.
    **Remove fillers** cuts every detected "um" / "uh" / etc. in one click.

--- a/components/ImportTranscriptOption.tsx
+++ b/components/ImportTranscriptOption.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { FileText, Loader2 } from "lucide-react";
+import { loadModelPreference } from "@/lib/models";
+import {
+  isTranscriptFile,
+  parseTranscriptFile,
+  TRANSCRIPT_ACCEPT,
+} from "@/lib/parseTranscript";
+import { useEditorStore } from "@/lib/store";
+import {
+  ModelOption,
+  useModelOption,
+  useOptionTrigger,
+  type ModelOptionContextValue,
+} from "./ModelSelector";
+
+/**
+ * ModelSelector option that opens a caption file picker and surfaces parse
+ * status / errors on the row (and in the closed trigger).
+ */
+export default function ImportTranscriptOption() {
+  const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
+  const setPendingTranscript = useEditorStore((s) => s.setPendingTranscript);
+  const setModel = useEditorStore((s) => s.setModel);
+  const [reading, setReading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<Pick<
+    ModelOptionContextValue,
+    "keepMenuOpen" | "select"
+  > | null>(null);
+
+  const triggerLabel = reading
+    ? "Import…"
+    : error
+      ? "Import failed"
+      : pendingTranscript
+        ? pendingTranscript.name
+        : "Import transcript";
+
+  return (
+    <ModelOption
+      id="import"
+      label="Import transcript"
+      meta="SRT / VTT / JSON"
+      icon={FileText}
+      autoTrigger={false}
+      onSelect={(ctx) => {
+        menuRef.current = ctx;
+        ctx.select();
+        setError(null);
+        ctx.keepMenuOpen();
+        requestAnimationFrame(() => fileRef.current?.click());
+      }}
+    >
+      <ImportTrigger
+        label={triggerLabel}
+        busy={reading}
+        error={Boolean(error)}
+      />
+      <input
+        ref={fileRef}
+        type="file"
+        accept={TRANSCRIPT_ACCEPT}
+        className="hidden"
+        onChange={(e) => {
+          const files = e.target.files;
+          e.target.value = "";
+          void (async () => {
+            const file = files?.[0];
+            const menu = menuRef.current;
+            if (!file) {
+              if (!pendingTranscript) {
+                setError(null);
+                setModel(loadModelPreference());
+              }
+              return;
+            }
+            if (!isTranscriptFile(file)) {
+              setError("Choose an SRT, VTT, or JSON file.");
+              setPendingTranscript(null);
+              menu?.keepMenuOpen();
+              return;
+            }
+            setReading(true);
+            setError(null);
+            menu?.keepMenuOpen();
+            try {
+              const words = await parseTranscriptFile(file);
+              setPendingTranscript({ name: file.name, words });
+              menu?.select();
+              menu?.keepMenuOpen();
+            } catch (err) {
+              console.error(err);
+              setPendingTranscript(null);
+              setError(
+                err instanceof Error
+                  ? err.message
+                  : "Could not read that transcript."
+              );
+              menu?.select();
+              menu?.keepMenuOpen();
+            } finally {
+              setReading(false);
+            }
+          })();
+        }}
+      />
+      <ImportStatus reading={reading} error={error} />
+    </ModelOption>
+  );
+}
+
+function ImportTrigger({
+  label,
+  busy,
+  error,
+}: {
+  label: string;
+  busy: boolean;
+  error: boolean;
+}) {
+  useOptionTrigger("import", {
+    label,
+    icon: FileText,
+    iconClassName: error ? "text-red-500" : "text-zinc-500",
+    busy,
+  });
+  return null;
+}
+
+function ImportStatus({
+  reading,
+  error,
+}: {
+  reading: boolean;
+  error: string | null;
+}) {
+  const { selected } = useModelOption();
+  const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
+  if (!selected || (!reading && !pendingTranscript && !error)) return null;
+  return (
+    <span
+      className={`pl-[1.625rem] text-[11px] leading-snug ${
+        error ? "text-red-500" : "text-zinc-500"
+      }`}
+    >
+      {reading ? (
+        <span className="inline-flex items-center gap-1">
+          <Loader2 size={11} className="animate-spin" />
+          Reading file…
+        </span>
+      ) : error ? (
+        error
+      ) : pendingTranscript ? (
+        `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
+      ) : null}
+    </span>
+  );
+}

--- a/components/ModelSelector.tsx
+++ b/components/ModelSelector.tsx
@@ -1,22 +1,36 @@
 "use client";
 
 import { useEffect, useId, useRef, useState } from "react";
-import { AudioLines, ChevronDown } from "lucide-react";
-import { MODEL_ORDER, MODELS, type ModelChoice } from "@/lib/models";
+import { AudioLines, ChevronDown, FileText, Loader2 } from "lucide-react";
+import {
+  MODELS,
+  WHISPER_ORDER,
+  loadModelPreference,
+  type WhisperModel,
+} from "@/lib/models";
+import {
+  isTranscriptFile,
+  parseTranscriptFile,
+  TRANSCRIPT_ACCEPT,
+} from "@/lib/parseTranscript";
 import { hydrateModelPreference, useEditorStore } from "@/lib/store";
 
 /**
- * Compact model picker for the upload screen header. Opens downward under the
- * trigger: group label + icon/name rows, with the trigger showing the current
- * choice.
+ * Compact source picker for the upload screen: Whisper Base / Small, or
+ * import an SRT/VTT/JSON transcript. Import status and errors stay inside
+ * the Import option row.
  */
 export default function ModelSelector() {
   const model = useEditorStore((s) => s.model);
   const setModel = useEditorStore((s) => s.setModel);
+  const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
+  const setPendingTranscript = useEditorStore((s) => s.setPendingTranscript);
   const [open, setOpen] = useState(false);
+  const [reading, setReading] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
   const listId = useId();
-  const current = MODELS[model];
 
   useEffect(() => {
     hydrateModelPreference();
@@ -38,10 +52,65 @@ export default function ModelSelector() {
     };
   }, [open]);
 
-  const select = (choice: ModelChoice) => {
+  const triggerLabel = (): string => {
+    if (model === "import") {
+      if (reading) return "Import…";
+      if (importError) return "Import failed";
+      if (pendingTranscript) return pendingTranscript.name;
+      return "Import transcript";
+    }
+    return MODELS[model].label;
+  };
+
+  const selectWhisper = (choice: WhisperModel) => {
+    setImportError(null);
     setModel(choice);
     setOpen(false);
   };
+
+  const selectImport = () => {
+    setModel("import");
+    setImportError(null);
+    // Keep the menu open so status/errors show on the Import row.
+    setOpen(true);
+    // Defer so the menu paints before the native picker steals focus.
+    requestAnimationFrame(() => fileRef.current?.click());
+  };
+
+  const onTranscriptPicked = async (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) {
+      // Cancelled the picker with nothing loaded — return to last Whisper model.
+      if (!pendingTranscript) {
+        setImportError(null);
+        setModel(loadModelPreference());
+      }
+      return;
+    }
+    if (!isTranscriptFile(file)) {
+      setImportError("Choose an SRT, VTT, or JSON file.");
+      setPendingTranscript(null);
+      return;
+    }
+    setReading(true);
+    setImportError(null);
+    try {
+      const words = await parseTranscriptFile(file);
+      setPendingTranscript({ name: file.name, words });
+      setModel("import");
+    } catch (err) {
+      console.error(err);
+      setPendingTranscript(null);
+      setImportError(
+        err instanceof Error ? err.message : "Could not read that transcript."
+      );
+      setModel("import");
+    } finally {
+      setReading(false);
+    }
+  };
+
+  const TriggerIcon = model === "import" ? FileText : AudioLines;
 
   return (
     <div ref={rootRef} className="relative shrink-0">
@@ -51,28 +120,47 @@ export default function ModelSelector() {
         aria-expanded={open}
         aria-controls={listId}
         onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-[13px] font-medium text-zinc-800 shadow-sm shadow-zinc-900/5 transition hover:border-zinc-300 hover:bg-zinc-50"
+        className="inline-flex max-w-[14rem] items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-[13px] font-medium text-zinc-800 shadow-sm shadow-zinc-900/5 transition hover:border-zinc-300 hover:bg-zinc-50"
       >
-        <AudioLines size={14} className="text-zinc-500" />
-        <span>{current.label}</span>
+        {reading ? (
+          <Loader2 size={14} className="shrink-0 animate-spin text-zinc-500" />
+        ) : (
+          <TriggerIcon
+            size={14}
+            className={`shrink-0 ${importError && model === "import" ? "text-red-500" : "text-zinc-500"}`}
+          />
+        )}
+        <span className="truncate">{triggerLabel()}</span>
         <ChevronDown
           size={14}
-          className={`text-zinc-400 transition ${open ? "rotate-180" : ""}`}
+          className={`shrink-0 text-zinc-400 transition ${open ? "rotate-180" : ""}`}
         />
       </button>
+
+      <input
+        ref={fileRef}
+        type="file"
+        accept={TRANSCRIPT_ACCEPT}
+        className="hidden"
+        onChange={(e) => {
+          const files = e.target.files;
+          e.target.value = "";
+          void onTranscriptPicked(files);
+        }}
+      />
 
       {open && (
         <div
           id={listId}
           role="listbox"
-          aria-label="Speech model"
+          aria-label="Transcript source"
           className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
         >
           <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
-            Speech model
+            Transcript source
           </p>
           <div className="p-1 pb-1.5">
-            {MODEL_ORDER.map((id) => {
+            {WHISPER_ORDER.map((id) => {
               const info = MODELS[id];
               const selected = id === model;
               return (
@@ -81,7 +169,7 @@ export default function ModelSelector() {
                   type="button"
                   role="option"
                   aria-selected={selected}
-                  onClick={() => select(id)}
+                  onClick={() => selectWhisper(id)}
                   className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition ${
                     selected
                       ? "bg-zinc-100 text-zinc-900"
@@ -99,6 +187,58 @@ export default function ModelSelector() {
                 </button>
               );
             })}
+
+            <div className="my-1 border-t border-zinc-100" />
+
+            <button
+              type="button"
+              role="option"
+              aria-selected={model === "import"}
+              onClick={selectImport}
+              className={`flex w-full flex-col gap-0.5 rounded-lg px-2.5 py-2 text-left transition ${
+                model === "import"
+                  ? "bg-zinc-100 text-zinc-900"
+                  : "text-zinc-700 hover:bg-zinc-50"
+              }`}
+            >
+              <span className="flex w-full items-center gap-2.5">
+                {reading ? (
+                  <Loader2 size={15} className="shrink-0 animate-spin text-zinc-500" />
+                ) : (
+                  <FileText
+                    size={15}
+                    className={
+                      model === "import"
+                        ? importError
+                          ? "text-red-500"
+                          : "text-zinc-700"
+                        : "text-zinc-400"
+                    }
+                  />
+                )}
+                <span className="min-w-0 flex-1 text-[13px] font-medium leading-tight">
+                  Import transcript
+                </span>
+                <span className="shrink-0 text-[11px] text-zinc-400">
+                  SRT / VTT / JSON
+                </span>
+              </span>
+              {model === "import" && (reading || pendingTranscript || importError) && (
+                <span
+                  className={`pl-[1.625rem] text-[11px] leading-snug ${
+                    importError ? "text-red-500" : "text-zinc-500"
+                  }`}
+                >
+                  {reading
+                    ? "Reading file…"
+                    : importError
+                      ? importError
+                      : pendingTranscript
+                        ? `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
+                        : null}
+                </span>
+              )}
+            </button>
           </div>
         </div>
       )}

--- a/components/ModelSelector.tsx
+++ b/components/ModelSelector.tsx
@@ -1,35 +1,91 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
-import { AudioLines, ChevronDown, FileText, Loader2 } from "lucide-react";
 import {
-  MODELS,
-  WHISPER_ORDER,
-  loadModelPreference,
-  type WhisperModel,
-} from "@/lib/models";
-import {
-  isTranscriptFile,
-  parseTranscriptFile,
-  TRANSCRIPT_ACCEPT,
-} from "@/lib/parseTranscript";
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { AudioLines, ChevronDown, Loader2, type LucideIcon } from "lucide-react";
+import { MODELS, isWhisperModel, type ModelChoice } from "@/lib/models";
 import { hydrateModelPreference, useEditorStore } from "@/lib/store";
 
+export type ModelOptionContextValue = {
+  /** Currently selected source id. */
+  value: ModelChoice;
+  selected: boolean;
+  select: () => void;
+  /** Close the dropdown after a normal selection. */
+  closeMenu: () => void;
+  /** Keep the menu open (file pickers, async status, …). */
+  keepMenuOpen: () => void;
+};
+
+export type OptionTrigger = {
+  label: ReactNode;
+  icon?: LucideIcon;
+  iconClassName?: string;
+  /** Show a spinner instead of the icon in the closed trigger. */
+  busy?: boolean;
+};
+
+type SelectorContextValue = {
+  value: ModelChoice;
+  setValue: (id: ModelChoice) => void;
+  closeMenu: () => void;
+  keepMenuOpen: () => void;
+  registerTrigger: (id: string, trigger: OptionTrigger) => void;
+  unregisterTrigger: (id: string) => void;
+};
+
+const ModelSelectorCtx = createContext<SelectorContextValue | null>(null);
+const OptionCtx = createContext<ModelOptionContextValue | null>(null);
+
+export function useModelOption(): ModelOptionContextValue {
+  const ctx = useContext(OptionCtx);
+  if (!ctx) {
+    throw new Error("useModelOption must be used inside a ModelSelector option");
+  }
+  return ctx;
+}
+
+/** Let a custom option drive the closed trigger while it is selected. */
+export function useOptionTrigger(
+  id: ModelChoice,
+  trigger: OptionTrigger,
+  enabled = true
+) {
+  const selector = useSelectorCtx();
+  const { label, icon, iconClassName, busy } = trigger;
+  useEffect(() => {
+    if (!enabled) return;
+    selector.registerTrigger(id, { label, icon, iconClassName, busy });
+    return () => selector.unregisterTrigger(id);
+  }, [selector, id, label, icon, iconClassName, busy, enabled]);
+}
+
 /**
- * Compact source picker for the upload screen: Whisper Base / Small, or
- * import an SRT/VTT/JSON transcript. Import status and errors stay inside
- * the Import option row.
+ * Generic source / model dropdown. Pass option components as children
+ * (`ModelOption`, or a custom option like `ImportTranscriptOption`).
+ * With no children, renders the default Whisper Base / Small rows.
  */
-export default function ModelSelector() {
+export default function ModelSelector({
+  children,
+  groupLabel = "Speech model",
+}: {
+  children?: ReactNode;
+  groupLabel?: string;
+}) {
   const model = useEditorStore((s) => s.model);
   const setModel = useEditorStore((s) => s.setModel);
-  const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
-  const setPendingTranscript = useEditorStore((s) => s.setPendingTranscript);
   const [open, setOpen] = useState(false);
-  const [reading, setReading] = useState(false);
-  const [importError, setImportError] = useState<string | null>(null);
+  const [triggers, setTriggers] = useState<Record<string, OptionTrigger>>({});
   const rootRef = useRef<HTMLDivElement>(null);
-  const fileRef = useRef<HTMLInputElement>(null);
   const listId = useId();
 
   useEffect(() => {
@@ -52,196 +108,198 @@ export default function ModelSelector() {
     };
   }, [open]);
 
-  const triggerLabel = (): string => {
-    if (model === "import") {
-      if (reading) return "Import…";
-      if (importError) return "Import failed";
-      if (pendingTranscript) return pendingTranscript.name;
-      return "Import transcript";
-    }
-    return MODELS[model].label;
-  };
+  const closeMenu = useCallback(() => setOpen(false), []);
+  const keepMenuOpen = useCallback(() => setOpen(true), []);
 
-  const selectWhisper = (choice: WhisperModel) => {
-    setImportError(null);
-    setModel(choice);
-    setOpen(false);
-  };
-
-  const selectImport = () => {
-    setModel("import");
-    setImportError(null);
-    // Keep the menu open so status/errors show on the Import row.
-    setOpen(true);
-    // Defer so the menu paints before the native picker steals focus.
-    requestAnimationFrame(() => fileRef.current?.click());
-  };
-
-  const onTranscriptPicked = async (files: FileList | null) => {
-    const file = files?.[0];
-    if (!file) {
-      // Cancelled the picker with nothing loaded — return to last Whisper model.
-      if (!pendingTranscript) {
-        setImportError(null);
-        setModel(loadModelPreference());
+  const registerTrigger = useCallback((id: string, trigger: OptionTrigger) => {
+    setTriggers((prev) => {
+      const cur = prev[id];
+      if (
+        cur &&
+        cur.label === trigger.label &&
+        cur.icon === trigger.icon &&
+        cur.iconClassName === trigger.iconClassName &&
+        cur.busy === trigger.busy
+      ) {
+        return prev;
       }
-      return;
-    }
-    if (!isTranscriptFile(file)) {
-      setImportError("Choose an SRT, VTT, or JSON file.");
-      setPendingTranscript(null);
-      return;
-    }
-    setReading(true);
-    setImportError(null);
-    try {
-      const words = await parseTranscriptFile(file);
-      setPendingTranscript({ name: file.name, words });
-      setModel("import");
-    } catch (err) {
-      console.error(err);
-      setPendingTranscript(null);
-      setImportError(
-        err instanceof Error ? err.message : "Could not read that transcript."
-      );
-      setModel("import");
-    } finally {
-      setReading(false);
-    }
-  };
+      return { ...prev, [id]: trigger };
+    });
+  }, []);
 
-  const TriggerIcon = model === "import" ? FileText : AudioLines;
+  const unregisterTrigger = useCallback((id: string) => {
+    setTriggers((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  const ctx = useMemo(
+    () => ({
+      value: model,
+      setValue: setModel,
+      closeMenu,
+      keepMenuOpen,
+      registerTrigger,
+      unregisterTrigger,
+    }),
+    [model, setModel, closeMenu, keepMenuOpen, registerTrigger, unregisterTrigger]
+  );
+
+  const activeTrigger = triggers[model];
+  const TriggerIcon = activeTrigger?.icon ?? AudioLines;
+  const triggerLabel =
+    activeTrigger?.label ??
+    (isWhisperModel(model) ? MODELS[model].label : model);
+
+  const options = children ?? (
+    <>
+      <ModelOption id="base" />
+      <ModelOption id="small" />
+    </>
+  );
 
   return (
-    <div ref={rootRef} className="relative shrink-0">
+    <ModelSelectorCtx.Provider value={ctx}>
+      <div ref={rootRef} className="relative shrink-0">
+        <button
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={listId}
+          onClick={() => setOpen((v) => !v)}
+          className="inline-flex max-w-[14rem] items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-[13px] font-medium text-zinc-800 shadow-sm shadow-zinc-900/5 transition hover:border-zinc-300 hover:bg-zinc-50"
+        >
+          {activeTrigger?.busy ? (
+            <Loader2 size={14} className="shrink-0 animate-spin text-zinc-500" />
+          ) : (
+            <TriggerIcon
+              size={14}
+              className={`shrink-0 ${activeTrigger?.iconClassName ?? "text-zinc-500"}`}
+            />
+          )}
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronDown
+            size={14}
+            className={`shrink-0 text-zinc-400 transition ${open ? "rotate-180" : ""}`}
+          />
+        </button>
+
+        {open && (
+          <div
+            id={listId}
+            role="listbox"
+            aria-label={groupLabel}
+            className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
+          >
+            <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
+              {groupLabel}
+            </p>
+            <div className="p-1 pb-1.5">{options}</div>
+          </div>
+        )}
+      </div>
+    </ModelSelectorCtx.Provider>
+  );
+}
+
+function useSelectorCtx(): SelectorContextValue {
+  const ctx = useContext(ModelSelectorCtx);
+  if (!ctx) {
+    throw new Error("Model option components must be used inside ModelSelector");
+  }
+  return ctx;
+}
+
+/** Default option row: icon + label + optional meta. Whisper ids fill in from MODELS. */
+export function ModelOption({
+  id,
+  label,
+  meta,
+  icon: Icon = AudioLines,
+  children,
+  onSelect,
+  /** When false, a child owns the closed trigger via `useOptionTrigger`. */
+  autoTrigger = true,
+}: {
+  id: ModelChoice;
+  label?: string;
+  meta?: string;
+  icon?: LucideIcon;
+  /** Extra content under the main row (status, errors, …). */
+  children?: ReactNode;
+  /** Override click handling. Defaults to set value + close. */
+  onSelect?: (ctx: ModelOptionContextValue) => void;
+  autoTrigger?: boolean;
+}) {
+  const selector = useSelectorCtx();
+  const selected = selector.value === id;
+
+  const resolvedLabel =
+    label ?? (isWhisperModel(id) ? MODELS[id].label : id);
+  const resolvedMeta =
+    meta ?? (isWhisperModel(id) ? MODELS[id].size : undefined);
+
+  const optionCtx = useMemo<ModelOptionContextValue>(
+    () => ({
+      value: selector.value,
+      selected,
+      select: () => selector.setValue(id),
+      closeMenu: selector.closeMenu,
+      keepMenuOpen: selector.keepMenuOpen,
+    }),
+    [selector, selected, id]
+  );
+
+  useOptionTrigger(
+    id,
+    { label: resolvedLabel, icon: Icon },
+    autoTrigger
+  );
+
+  const handleClick = () => {
+    if (onSelect) {
+      onSelect(optionCtx);
+      return;
+    }
+    optionCtx.select();
+    optionCtx.closeMenu();
+  };
+
+  return (
+    <OptionCtx.Provider value={optionCtx}>
       <button
         type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={listId}
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex max-w-[14rem] items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-[13px] font-medium text-zinc-800 shadow-sm shadow-zinc-900/5 transition hover:border-zinc-300 hover:bg-zinc-50"
+        role="option"
+        aria-selected={selected}
+        onClick={handleClick}
+        className={`flex w-full flex-col gap-0.5 rounded-lg px-2.5 py-2 text-left transition ${
+          selected
+            ? "bg-zinc-100 text-zinc-900"
+            : "text-zinc-700 hover:bg-zinc-50"
+        }`}
       >
-        {reading ? (
-          <Loader2 size={14} className="shrink-0 animate-spin text-zinc-500" />
-        ) : (
-          <TriggerIcon
-            size={14}
-            className={`shrink-0 ${importError && model === "import" ? "text-red-500" : "text-zinc-500"}`}
+        <span className="flex w-full items-center gap-2.5">
+          <Icon
+            size={15}
+            className={selected ? "text-zinc-700" : "text-zinc-400"}
           />
-        )}
-        <span className="truncate">{triggerLabel()}</span>
-        <ChevronDown
-          size={14}
-          className={`shrink-0 text-zinc-400 transition ${open ? "rotate-180" : ""}`}
-        />
+          <span className="min-w-0 flex-1 text-[13px] font-medium leading-tight">
+            {resolvedLabel}
+          </span>
+          {resolvedMeta && (
+            <span className="shrink-0 text-[11px] text-zinc-400">{resolvedMeta}</span>
+          )}
+        </span>
+        {children}
       </button>
-
-      <input
-        ref={fileRef}
-        type="file"
-        accept={TRANSCRIPT_ACCEPT}
-        className="hidden"
-        onChange={(e) => {
-          const files = e.target.files;
-          e.target.value = "";
-          void onTranscriptPicked(files);
-        }}
-      />
-
-      {open && (
-        <div
-          id={listId}
-          role="listbox"
-          aria-label="Transcript source"
-          className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
-        >
-          <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
-            Transcript source
-          </p>
-          <div className="p-1 pb-1.5">
-            {WHISPER_ORDER.map((id) => {
-              const info = MODELS[id];
-              const selected = id === model;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  role="option"
-                  aria-selected={selected}
-                  onClick={() => selectWhisper(id)}
-                  className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition ${
-                    selected
-                      ? "bg-zinc-100 text-zinc-900"
-                      : "text-zinc-700 hover:bg-zinc-50"
-                  }`}
-                >
-                  <AudioLines
-                    size={15}
-                    className={selected ? "text-zinc-700" : "text-zinc-400"}
-                  />
-                  <span className="min-w-0 flex-1 text-[13px] font-medium leading-tight">
-                    {info.label}
-                  </span>
-                  <span className="shrink-0 text-[11px] text-zinc-400">{info.size}</span>
-                </button>
-              );
-            })}
-
-            <div className="my-1 border-t border-zinc-100" />
-
-            <button
-              type="button"
-              role="option"
-              aria-selected={model === "import"}
-              onClick={selectImport}
-              className={`flex w-full flex-col gap-0.5 rounded-lg px-2.5 py-2 text-left transition ${
-                model === "import"
-                  ? "bg-zinc-100 text-zinc-900"
-                  : "text-zinc-700 hover:bg-zinc-50"
-              }`}
-            >
-              <span className="flex w-full items-center gap-2.5">
-                {reading ? (
-                  <Loader2 size={15} className="shrink-0 animate-spin text-zinc-500" />
-                ) : (
-                  <FileText
-                    size={15}
-                    className={
-                      model === "import"
-                        ? importError
-                          ? "text-red-500"
-                          : "text-zinc-700"
-                        : "text-zinc-400"
-                    }
-                  />
-                )}
-                <span className="min-w-0 flex-1 text-[13px] font-medium leading-tight">
-                  Import transcript
-                </span>
-                <span className="shrink-0 text-[11px] text-zinc-400">
-                  SRT / VTT / JSON
-                </span>
-              </span>
-              {model === "import" && (reading || pendingTranscript || importError) && (
-                <span
-                  className={`pl-[1.625rem] text-[11px] leading-snug ${
-                    importError ? "text-red-500" : "text-zinc-500"
-                  }`}
-                >
-                  {reading
-                    ? "Reading file…"
-                    : importError
-                      ? importError
-                      : pendingTranscript
-                        ? `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
-                        : null}
-                </span>
-              )}
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
+    </OptionCtx.Provider>
   );
+}
+
+/** Separator between option groups (e.g. Whisper vs import). */
+export function ModelOptionSeparator() {
+  return <div className="my-1 border-t border-zinc-100" role="separator" />;
 }

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Eye, EyeOff, Pencil, RotateCcw, Scissors, WandSparkles, X } from "lucide-react";
+import { Eye, EyeOff, FileText, Pencil, RotateCcw, Scissors, WandSparkles, X } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import { findFillerWordIds } from "@/lib/fillers";
+import {
+  isTranscriptFile,
+  parseTranscriptFile,
+  TRANSCRIPT_ACCEPT,
+} from "@/lib/parseTranscript";
 import type { SpeakerTurn, Word } from "@/lib/types";
 
 export const SPEAKER_COLORS = [
@@ -82,11 +87,13 @@ export default function TranscriptPanel() {
   const deleteWords = useEditorStore((s) => s.deleteWords);
   const restoreWords = useEditorStore((s) => s.restoreWords);
   const correctWords = useEditorStore((s) => s.correctWords);
+  const importWords = useEditorStore((s) => s.importWords);
   const playing = useEditorStore((s) => s.playing);
   const activeWordId = useEditorStore((s) => findActiveWordId(s.words, s.currentTime));
 
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [correcting, setCorrecting] = useState<{
     ids: number[];
@@ -115,6 +122,31 @@ export default function TranscriptPanel() {
   const removeFillers = useCallback(() => {
     deleteWords(fillerIds);
   }, [deleteWords, fillerIds]);
+
+  const handleImportTranscript = useCallback(
+    async (files: FileList | null) => {
+      const file = files?.[0];
+      if (!file) return;
+      if (!isTranscriptFile(file)) {
+        alert("Please choose an SRT, VTT, or JSON transcript.");
+        return;
+      }
+      if (
+        words.length > 0 &&
+        !confirm("Replace the current transcript with this file?")
+      ) {
+        return;
+      }
+      try {
+        const imported = await parseTranscriptFile(file);
+        importWords(imported);
+      } catch (err) {
+        console.error(err);
+        alert(err instanceof Error ? err.message : "Could not read that transcript.");
+      }
+    },
+    [words.length, importWords]
+  );
 
   const seekToWord = useCallback((word: Word) => {
     const { videoEl, setCurrentTime } = useEditorStore.getState();
@@ -296,6 +328,29 @@ export default function TranscriptPanel() {
               <WandSparkles size={14} />
               Remove fillers ({fillerIds.length})
             </button>
+          )}
+          {(status === "ready" || status === "error" || status === "transcribing") && (
+            <>
+              <button
+                onClick={() => importInputRef.current?.click()}
+                title="Replace transcript from SRT, VTT, or JSON"
+                className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100"
+              >
+                <FileText size={14} />
+                Import
+              </button>
+              <input
+                ref={importInputRef}
+                type="file"
+                accept={TRANSCRIPT_ACCEPT}
+                className="hidden"
+                onChange={(e) => {
+                  const files = e.target.files;
+                  e.target.value = "";
+                  void handleImportTranscript(files);
+                }}
+              />
+            </>
           )}
           <button
             onClick={toggleShowDeleted}

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -5,7 +5,6 @@ import Image from "next/image";
 import {
   AudioLines,
   Clapperboard,
-  FileText,
   Film,
   Loader2,
   Lock,
@@ -14,18 +13,12 @@ import {
   ShieldAlert,
   Trash2,
   Type,
-  X,
 } from "lucide-react";
 import logo from "@/assets/logo.png";
 import GitHubLink from "./GitHubLink";
 import ModelSelector from "./ModelSelector";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
 import { detectMediaKind, MEDIA_ACCEPT } from "@/lib/media";
-import {
-  isTranscriptFile,
-  parseTranscriptFile,
-  TRANSCRIPT_ACCEPT,
-} from "@/lib/parseTranscript";
 import { formatTime } from "@/lib/edits";
 import {
   formatRelativeTime,
@@ -159,20 +152,16 @@ export default function UploadScreen({
   onFile: (file: File, options?: { words?: Word[] }) => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const mediaInputRef = useRef<HTMLInputElement>(null);
-  const transcriptInputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
   const [projects, setProjects] = useState<ProjectMeta[]>([]);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [importOpen, setImportOpen] = useState(false);
-  const [importMedia, setImportMedia] = useState<File | null>(null);
-  const [importTranscript, setImportTranscript] = useState<File | null>(null);
-  const [importBusy, setImportBusy] = useState(false);
   // The pipeline needs SharedArrayBuffer, which on static hosts only appears
   // after the COI service worker reloads the page. Accepting a file before then
   // would fail immediately and lose the file to that reload.
   const isolation = useCrossOriginIsolated();
   const ready = isolation === "ready";
+  const model = useEditorStore((s) => s.model);
+  const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
   const openProject = useEditorStore((s) => s.openProject);
   const removeProject = useEditorStore((s) => s.removeProject);
 
@@ -210,6 +199,16 @@ export default function UploadScreen({
         alert("Please choose a video or audio file.");
         return;
       }
+      const { model: source, pendingTranscript: pending } =
+        useEditorStore.getState();
+      if (source === "import") {
+        if (!pending) {
+          alert("Choose a transcript file from the source menu first.");
+          return;
+        }
+        onFile(file, { words: pending.words });
+        return;
+      }
       onFile(file);
     },
     [onFile, ready]
@@ -244,26 +243,6 @@ export default function UploadScreen({
     },
     [removeProject, refreshProjects]
   );
-
-  const closeImport = useCallback(() => {
-    setImportOpen(false);
-    setImportMedia(null);
-    setImportTranscript(null);
-    setImportBusy(false);
-  }, []);
-
-  const startImport = useCallback(async () => {
-    if (!ready || !importMedia || !importTranscript) return;
-    setImportBusy(true);
-    try {
-      const words = await parseTranscriptFile(importTranscript);
-      onFile(importMedia, { words });
-    } catch (err) {
-      console.error(err);
-      alert(err instanceof Error ? err.message : "Could not read that transcript.");
-      setImportBusy(false);
-    }
-  }, [ready, importMedia, importTranscript, onFile]);
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain bg-gradient-to-b from-zinc-50 to-neutral-50/50">
@@ -343,7 +322,11 @@ export default function UploadScreen({
                 <span className="text-neutral-600">browse</span>
               </p>
               <p className="mt-1 text-[13px] text-zinc-400">
-                MP4, WebM, MOV, MP3, WAV, M4A, …
+                {model === "import"
+                  ? pendingTranscript
+                    ? `Will use ${pendingTranscript.name} · MP4, WebM, MOV, MP3, WAV, …`
+                    : "Pick a transcript in the menu above, then drop your media"
+                  : "MP4, WebM, MOV, MP3, WAV, M4A, …"}
               </p>
             </>
           ) : (
@@ -362,113 +345,6 @@ export default function UploadScreen({
             onChange={(e) => handleFiles(e.target.files)}
           />
         </div>
-
-        {ready && !importOpen && (
-          <p className="mt-3 text-center text-[13px] text-zinc-400">
-            Or{" "}
-            <button
-              type="button"
-              onClick={() => setImportOpen(true)}
-              className="font-medium text-zinc-600 underline-offset-2 transition hover:text-zinc-900 hover:underline"
-            >
-              import your own transcript
-            </button>{" "}
-            (SRT, VTT, JSON)
-          </p>
-        )}
-
-        {ready && importOpen && (
-          <div className="mt-4 rounded-2xl border border-zinc-200 bg-white/80 p-4">
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2 text-[13px] font-medium text-zinc-800">
-                <FileText size={15} className="text-zinc-500" />
-                Import media + transcript
-              </div>
-              <button
-                type="button"
-                onClick={closeImport}
-                className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700"
-                title="Cancel"
-              >
-                <X size={14} />
-              </button>
-            </div>
-            <p className="mb-3 text-xs leading-relaxed text-zinc-500">
-              Skip Whisper and edit with timings from your caption file. Speakers
-              are taken from VTT voice tags or <span className="font-mono">Name:</span>{" "}
-              labels when present.
-            </p>
-            <div className="grid gap-2 sm:grid-cols-2">
-              <button
-                type="button"
-                onClick={() => mediaInputRef.current?.click()}
-                className="flex flex-col items-start gap-0.5 rounded-xl border border-dashed border-zinc-300 px-3 py-3 text-left transition hover:border-neutral-400 hover:bg-zinc-50"
-              >
-                <span className="text-[12px] font-medium text-zinc-700">Media</span>
-                <span className="w-full truncate text-[11px] text-zinc-400">
-                  {importMedia ? importMedia.name : "Choose video or audio…"}
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => transcriptInputRef.current?.click()}
-                className="flex flex-col items-start gap-0.5 rounded-xl border border-dashed border-zinc-300 px-3 py-3 text-left transition hover:border-neutral-400 hover:bg-zinc-50"
-              >
-                <span className="text-[12px] font-medium text-zinc-700">Transcript</span>
-                <span className="w-full truncate text-[11px] text-zinc-400">
-                  {importTranscript ? importTranscript.name : "Choose SRT, VTT, or JSON…"}
-                </span>
-              </button>
-            </div>
-            <input
-              ref={mediaInputRef}
-              type="file"
-              accept={MEDIA_ACCEPT}
-              className="hidden"
-              onChange={(e) => {
-                const file = e.target.files?.[0] ?? null;
-                e.target.value = "";
-                if (!file) return;
-                if (!detectMediaKind(file)) {
-                  alert("Please choose a video or audio file.");
-                  return;
-                }
-                setImportMedia(file);
-              }}
-            />
-            <input
-              ref={transcriptInputRef}
-              type="file"
-              accept={TRANSCRIPT_ACCEPT}
-              className="hidden"
-              onChange={(e) => {
-                const file = e.target.files?.[0] ?? null;
-                e.target.value = "";
-                if (!file) return;
-                if (!isTranscriptFile(file)) {
-                  alert("Please choose an SRT, VTT, or JSON transcript.");
-                  return;
-                }
-                setImportTranscript(file);
-              }}
-            />
-            <button
-              type="button"
-              disabled={!importMedia || !importTranscript || importBusy}
-              onClick={() => void startImport()}
-              className="mt-3 flex h-9 w-full items-center justify-center gap-2 rounded-full bg-zinc-900 text-[13px] font-medium text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {importBusy ? (
-                <>
-                  <Loader2 size={14} className="animate-spin" />
-                  Reading transcript…
-                </>
-              ) : (
-                "Start editing"
-              )}
-            </button>
-          </div>
-        )}
 
         {ready && (
           <RecentProjects

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -16,7 +16,11 @@ import {
 } from "lucide-react";
 import logo from "@/assets/logo.png";
 import GitHubLink from "./GitHubLink";
-import ModelSelector from "./ModelSelector";
+import ModelSelector, {
+  ModelOption,
+  ModelOptionSeparator,
+} from "./ModelSelector";
+import ImportTranscriptOption from "./ImportTranscriptOption";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
 import { detectMediaKind, MEDIA_ACCEPT } from "@/lib/media";
 import { formatTime } from "@/lib/edits";
@@ -262,7 +266,12 @@ export default function UploadScreen({
             />
             <p className="ml-2 text-[15px] font-medium text-zinc-800">Rescript</p>
           </div>
-          <ModelSelector />
+          <ModelSelector groupLabel="Transcript source">
+            <ModelOption id="base" />
+            <ModelOption id="small" />
+            <ModelOptionSeparator />
+            <ImportTranscriptOption />
+          </ModelSelector>
         </div>
         <div
           role="button"

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import {
   AudioLines,
   Clapperboard,
+  FileText,
   Film,
   Loader2,
   Lock,
@@ -13,12 +14,18 @@ import {
   ShieldAlert,
   Trash2,
   Type,
+  X,
 } from "lucide-react";
 import logo from "@/assets/logo.png";
 import GitHubLink from "./GitHubLink";
 import ModelSelector from "./ModelSelector";
 import { useCrossOriginIsolated } from "@/hooks/useCrossOriginIsolated";
 import { detectMediaKind, MEDIA_ACCEPT } from "@/lib/media";
+import {
+  isTranscriptFile,
+  parseTranscriptFile,
+  TRANSCRIPT_ACCEPT,
+} from "@/lib/parseTranscript";
 import { formatTime } from "@/lib/edits";
 import {
   formatRelativeTime,
@@ -26,6 +33,7 @@ import {
   type ProjectMeta,
 } from "@/lib/projects";
 import { useEditorStore } from "@/lib/store";
+import type { Word } from "@/lib/types";
 
 // The three media cards that stand in for the upload icon. Each carries its
 // resting transform plus the fanned-out one, applied either on hover (via the
@@ -145,11 +153,21 @@ function RecentProjects({
   );
 }
 
-export default function UploadScreen({ onFile }: { onFile: (file: File) => void }) {
+export default function UploadScreen({
+  onFile,
+}: {
+  onFile: (file: File, options?: { words?: Word[] }) => void;
+}) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const mediaInputRef = useRef<HTMLInputElement>(null);
+  const transcriptInputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
   const [projects, setProjects] = useState<ProjectMeta[]>([]);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
+  const [importMedia, setImportMedia] = useState<File | null>(null);
+  const [importTranscript, setImportTranscript] = useState<File | null>(null);
+  const [importBusy, setImportBusy] = useState(false);
   // The pipeline needs SharedArrayBuffer, which on static hosts only appears
   // after the COI service worker reloads the page. Accepting a file before then
   // would fail immediately and lose the file to that reload.
@@ -226,6 +244,26 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
     },
     [removeProject, refreshProjects]
   );
+
+  const closeImport = useCallback(() => {
+    setImportOpen(false);
+    setImportMedia(null);
+    setImportTranscript(null);
+    setImportBusy(false);
+  }, []);
+
+  const startImport = useCallback(async () => {
+    if (!ready || !importMedia || !importTranscript) return;
+    setImportBusy(true);
+    try {
+      const words = await parseTranscriptFile(importTranscript);
+      onFile(importMedia, { words });
+    } catch (err) {
+      console.error(err);
+      alert(err instanceof Error ? err.message : "Could not read that transcript.");
+      setImportBusy(false);
+    }
+  }, [ready, importMedia, importTranscript, onFile]);
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain bg-gradient-to-b from-zinc-50 to-neutral-50/50">
@@ -325,6 +363,113 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
           />
         </div>
 
+        {ready && !importOpen && (
+          <p className="mt-3 text-center text-[13px] text-zinc-400">
+            Or{" "}
+            <button
+              type="button"
+              onClick={() => setImportOpen(true)}
+              className="font-medium text-zinc-600 underline-offset-2 transition hover:text-zinc-900 hover:underline"
+            >
+              import your own transcript
+            </button>{" "}
+            (SRT, VTT, JSON)
+          </p>
+        )}
+
+        {ready && importOpen && (
+          <div className="mt-4 rounded-2xl border border-zinc-200 bg-white/80 p-4">
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 text-[13px] font-medium text-zinc-800">
+                <FileText size={15} className="text-zinc-500" />
+                Import media + transcript
+              </div>
+              <button
+                type="button"
+                onClick={closeImport}
+                className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700"
+                title="Cancel"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <p className="mb-3 text-xs leading-relaxed text-zinc-500">
+              Skip Whisper and edit with timings from your caption file. Speakers
+              are taken from VTT voice tags or <span className="font-mono">Name:</span>{" "}
+              labels when present.
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => mediaInputRef.current?.click()}
+                className="flex flex-col items-start gap-0.5 rounded-xl border border-dashed border-zinc-300 px-3 py-3 text-left transition hover:border-neutral-400 hover:bg-zinc-50"
+              >
+                <span className="text-[12px] font-medium text-zinc-700">Media</span>
+                <span className="w-full truncate text-[11px] text-zinc-400">
+                  {importMedia ? importMedia.name : "Choose video or audio…"}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => transcriptInputRef.current?.click()}
+                className="flex flex-col items-start gap-0.5 rounded-xl border border-dashed border-zinc-300 px-3 py-3 text-left transition hover:border-neutral-400 hover:bg-zinc-50"
+              >
+                <span className="text-[12px] font-medium text-zinc-700">Transcript</span>
+                <span className="w-full truncate text-[11px] text-zinc-400">
+                  {importTranscript ? importTranscript.name : "Choose SRT, VTT, or JSON…"}
+                </span>
+              </button>
+            </div>
+            <input
+              ref={mediaInputRef}
+              type="file"
+              accept={MEDIA_ACCEPT}
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null;
+                e.target.value = "";
+                if (!file) return;
+                if (!detectMediaKind(file)) {
+                  alert("Please choose a video or audio file.");
+                  return;
+                }
+                setImportMedia(file);
+              }}
+            />
+            <input
+              ref={transcriptInputRef}
+              type="file"
+              accept={TRANSCRIPT_ACCEPT}
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null;
+                e.target.value = "";
+                if (!file) return;
+                if (!isTranscriptFile(file)) {
+                  alert("Please choose an SRT, VTT, or JSON transcript.");
+                  return;
+                }
+                setImportTranscript(file);
+              }}
+            />
+            <button
+              type="button"
+              disabled={!importMedia || !importTranscript || importBusy}
+              onClick={() => void startImport()}
+              className="mt-3 flex h-9 w-full items-center justify-center gap-2 rounded-full bg-zinc-900 text-[13px] font-medium text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {importBusy ? (
+                <>
+                  <Loader2 size={14} className="animate-spin" />
+                  Reading transcript…
+                </>
+              ) : (
+                "Start editing"
+              )}
+            </button>
+          </div>
+        )}
+
         {ready && (
           <RecentProjects
             projects={projects}
@@ -336,7 +481,7 @@ export default function UploadScreen({ onFile }: { onFile: (file: File) => void 
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
           {[
-            { icon: Type, title: "Transcribe", text: "Per-word timing and speaker labels." },
+            { icon: Type, title: "Transcribe", text: "Whisper locally, or import SRT / VTT." },
             { icon: Scissors, title: "Edit", text: "Select words and hit delete to edit." },
             { icon: Clapperboard, title: "Export", text: "Render the final cut to MP4 or M4A." },
           ].map(({ icon: Icon, title, text }) => (

--- a/hooks/useTranscriber.ts
+++ b/hooks/useTranscriber.ts
@@ -4,13 +4,21 @@ import { useCallback, useEffect, useRef } from "react";
 import { useEditorStore } from "@/lib/store";
 import type { WorkerResponse } from "@/lib/types";
 
+let activeWorker: Worker | null = null;
+
+/** Stop an in-flight Whisper job (e.g. after importing a transcript). */
+export function cancelTranscription() {
+  activeWorker?.terminate();
+  activeWorker = null;
+}
+
 /** Owns the transcription web worker and pipes its messages into the store. */
 export function useTranscriber() {
   const workerRef = useRef<Worker | null>(null);
 
   useEffect(() => {
     return () => {
-      workerRef.current?.terminate();
+      cancelTranscription();
       workerRef.current = null;
     };
   }, []);
@@ -20,35 +28,40 @@ export function useTranscriber() {
     store.setStatus("transcribing");
     store.setProgress({ message: "Loading speech model…", value: null });
 
-    if (!workerRef.current) {
-      workerRef.current = new Worker(
-        new URL("../workers/transcription.worker.ts", import.meta.url),
-        { type: "module" }
-      );
-      workerRef.current.onmessage = (event: MessageEvent<WorkerResponse>) => {
-        const s = useEditorStore.getState();
-        const msg = event.data;
-        switch (msg.type) {
-          case "progress":
-            s.setProgress({ message: msg.message, value: msg.value });
-            break;
-          case "partial":
-            s.setPartialText(msg.text);
-            break;
-          case "complete":
-            s.setWords(msg.words);
-            s.setStatus("ready");
-            s.setPartialText("");
-            break;
-          case "error":
-            s.setError(msg.message);
-            break;
-        }
-      };
-      workerRef.current.onerror = (err) => {
-        useEditorStore.getState().setError(err.message || "Transcription worker crashed.");
-      };
-    }
+    // Always start a fresh worker so a prior cancel can't leave us without one.
+    cancelTranscription();
+    workerRef.current = new Worker(
+      new URL("../workers/transcription.worker.ts", import.meta.url),
+      { type: "module" }
+    );
+    activeWorker = workerRef.current;
+    workerRef.current.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const s = useEditorStore.getState();
+      // An imported transcript sets skipTranscription; ignore late Whisper results.
+      if (s.skipTranscription) return;
+      const msg = event.data;
+      switch (msg.type) {
+        case "progress":
+          s.setProgress({ message: msg.message, value: msg.value });
+          break;
+        case "partial":
+          s.setPartialText(msg.text);
+          break;
+        case "complete":
+          s.setWords(msg.words);
+          s.setStatus("ready");
+          s.setPartialText("");
+          break;
+        case "error":
+          s.setError(msg.message);
+          break;
+      }
+    };
+    workerRef.current.onerror = (err) => {
+      const s = useEditorStore.getState();
+      if (s.skipTranscription) return;
+      s.setError(err.message || "Transcription worker crashed.");
+    };
 
     // Transfer a copy so the original stays available for the waveform.
     const copy = audio.slice();
@@ -58,5 +71,5 @@ export function useTranscriber() {
     );
   }, []);
 
-  return { transcribe };
+  return { transcribe, cancel: cancelTranscription };
 }

--- a/hooks/useTranscriber.ts
+++ b/hooks/useTranscriber.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import { isWhisperModel } from "@/lib/models";
 import { useEditorStore } from "@/lib/store";
 import type { WorkerResponse } from "@/lib/types";
 
@@ -25,6 +26,11 @@ export function useTranscriber() {
 
   const transcribe = useCallback((audio: Float32Array, duration: number) => {
     const store = useEditorStore.getState();
+    if (!isWhisperModel(store.model)) {
+      store.setError("Select Whisper Base or Small to transcribe.");
+      return;
+    }
+    const whisperModel = store.model;
     store.setStatus("transcribing");
     store.setProgress({ message: "Loading speech model…", value: null });
 
@@ -66,7 +72,7 @@ export function useTranscriber() {
     // Transfer a copy so the original stays available for the waveform.
     const copy = audio.slice();
     workerRef.current.postMessage(
-      { audio: copy, duration, model: store.model },
+      { audio: copy, duration, model: whisperModel },
       [copy.buffer]
     );
   }, []);

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,5 +1,6 @@
-/** Transcription model choices offered on the upload screen. */
-export type ModelChoice = "base" | "small";
+/** Transcription source choices offered on the upload screen. */
+export type WhisperModel = "base" | "small";
+export type ModelChoice = WhisperModel | "import";
 
 type DType = "fp32" | "fp16" | "q8" | "int8" | "uint8" | "q4" | "q4f16" | "bnb4";
 
@@ -28,8 +29,11 @@ export interface ModelInfo {
   verbatimPrompt?: string;
 }
 
-/** Display order for the homepage model dropdown. */
-export const MODEL_ORDER: ModelChoice[] = ["base", "small"];
+/** Display order for Whisper rows in the homepage source dropdown. */
+export const WHISPER_ORDER: WhisperModel[] = ["base", "small"];
+
+/** @deprecated Prefer WHISPER_ORDER; kept for older imports. */
+export const MODEL_ORDER = WHISPER_ORDER;
 
 const WHISPER_DTYPE = {
   // q4 decoder: q8 fails session creation on onnxruntime-web 1.26
@@ -38,7 +42,8 @@ const WHISPER_DTYPE = {
   wasm: { encoder_model: "fp32", decoder_model_merged: "q4" },
 } satisfies ModelInfo["dtype"];
 
-export const MODELS: Record<ModelChoice, ModelInfo> = {
+/** Whisper models that can run in the transcription worker. */
+export const MODELS: Record<WhisperModel, ModelInfo> = {
   base: {
     id: "onnx-community/whisper-base_timestamped",
     label: "Whisper Base",
@@ -58,26 +63,32 @@ export const MODELS: Record<ModelChoice, ModelInfo> = {
   },
 };
 
-const MODEL_STORAGE_KEY = "rescript.model";
-
-export function isModelChoice(value: unknown): value is ModelChoice {
-  return typeof value === "string" && value in MODELS;
+export function isWhisperModel(value: unknown): value is WhisperModel {
+  return value === "base" || value === "small";
 }
 
-/** Read the last-selected model from localStorage (defaults to base). */
-export function loadModelPreference(): ModelChoice {
+export function isModelChoice(value: unknown): value is ModelChoice {
+  return isWhisperModel(value) || value === "import";
+}
+
+const MODEL_STORAGE_KEY = "rescript.model";
+
+/** Read the last-selected Whisper model from localStorage (defaults to base). */
+export function loadModelPreference(): WhisperModel {
   if (typeof window === "undefined") return "base";
   try {
     const raw = window.localStorage.getItem(MODEL_STORAGE_KEY);
-    if (isModelChoice(raw)) return raw;
+    // Ignore a stale "import" preference — that choice is session-only until a
+    // transcript file is picked again.
+    if (isWhisperModel(raw)) return raw;
   } catch {
     // private mode / disabled storage
   }
   return "base";
 }
 
-/** Persist the selected model for the next visit. */
-export function saveModelPreference(model: ModelChoice) {
+/** Persist the selected Whisper model for the next visit. */
+export function saveModelPreference(model: WhisperModel) {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(MODEL_STORAGE_KEY, model);

--- a/lib/parseTranscript.ts
+++ b/lib/parseTranscript.ts
@@ -1,0 +1,276 @@
+import type { Word } from "./types";
+
+/** Caption / transcript files we can turn into timed words. */
+export const TRANSCRIPT_ACCEPT =
+  ".srt,.vtt,.json,application/json,text/vtt,text/plain";
+
+const TRANSCRIPT_EXT = /\.(srt|vtt|json)$/i;
+
+export function isTranscriptFile(file: File): boolean {
+  return (
+    TRANSCRIPT_EXT.test(file.name) ||
+    file.type === "application/json" ||
+    file.type === "text/vtt"
+  );
+}
+
+interface Cue {
+  start: number;
+  end: number;
+  text: string;
+  speaker?: string;
+}
+
+/**
+ * Parse an SRT, WebVTT, or JSON transcript into editor `Word`s.
+ * Cue text is split on whitespace; each cue's time span is distributed
+ * across its tokens by character length (same idea as word correction).
+ */
+export function parseTranscript(text: string, filename = ""): Word[] {
+  const trimmed = text.replace(/^\uFEFF/, "").trim();
+  if (!trimmed) throw new Error("That transcript file is empty.");
+
+  const lower = filename.toLowerCase();
+  let words: Word[];
+  if (lower.endsWith(".json") || looksLikeJson(trimmed)) {
+    words = wordsFromJson(trimmed);
+  } else if (lower.endsWith(".vtt") || /^WEBVTT/i.test(trimmed)) {
+    words = wordsFromCues(parseVtt(trimmed));
+  } else if (lower.endsWith(".srt") || looksLikeSrt(trimmed)) {
+    words = wordsFromCues(parseSrt(trimmed));
+  } else {
+    // Fallbacks when the extension is missing or wrong.
+    try {
+      words = wordsFromJson(trimmed);
+    } catch {
+      try {
+        words = wordsFromCues(parseVtt(trimmed));
+      } catch {
+        words = wordsFromCues(parseSrt(trimmed));
+      }
+    }
+  }
+
+  if (words.length === 0) {
+    throw new Error("No timed words found in that transcript.");
+  }
+  return words;
+}
+
+export async function parseTranscriptFile(file: File): Promise<Word[]> {
+  const text = await file.text();
+  return parseTranscript(text, file.name);
+}
+
+function looksLikeJson(text: string): boolean {
+  const c = text[0];
+  return c === "[" || c === "{";
+}
+
+function looksLikeSrt(text: string): boolean {
+  return /\d{1,2}:\d{2}:\d{2}[,.]\d{1,3}\s*-->\s*\d{1,2}:\d{2}:\d{2}[,.]\d{1,3}/.test(
+    text
+  );
+}
+
+function wordsFromJson(text: string): Word[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error("Could not parse that JSON transcript.");
+  }
+
+  const rows = Array.isArray(data)
+    ? data
+    : data &&
+        typeof data === "object" &&
+        Array.isArray((data as { words?: unknown }).words)
+      ? (data as { words: unknown[] }).words
+      : null;
+  if (!rows) {
+    throw new Error('JSON must be a word array or { "words": [...] }.');
+  }
+
+  const nameToIdx = new Map<string, number>();
+  let nextSpeaker = 0;
+  const words: Word[] = [];
+
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue;
+    const r = row as Record<string, unknown>;
+    const token = String(r.text ?? r.word ?? "").trim();
+    const start = Number(r.start);
+    const end = Number(r.end);
+    if (!token || !Number.isFinite(start) || !Number.isFinite(end)) continue;
+
+    let speaker = 0;
+    if (typeof r.speaker === "number" && Number.isFinite(r.speaker)) {
+      speaker = Math.max(0, Math.floor(r.speaker));
+    } else if (typeof r.speaker === "string" && r.speaker.trim()) {
+      const name = r.speaker.trim();
+      if (!nameToIdx.has(name)) nameToIdx.set(name, nextSpeaker++);
+      speaker = nameToIdx.get(name)!;
+    }
+
+    const s = Math.max(0, start);
+    words.push({
+      id: words.length,
+      text: token,
+      start: s,
+      end: Math.max(s + 0.02, end),
+      speaker,
+      deleted: Boolean(r.deleted),
+    });
+  }
+
+  return words;
+}
+
+function parseSrt(text: string): Cue[] {
+  const blocks = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split(/\n\n+/);
+  const cues: Cue[] = [];
+  for (const block of blocks) {
+    const lines = block.split("\n").map((l) => l.trimEnd()).filter((l, i, arr) => {
+      // Keep blank lines out; allow content lines.
+      return l.length > 0 || i === arr.length - 1;
+    }).filter((l) => l.length > 0);
+    if (lines.length < 2) continue;
+    let idx = 0;
+    if (/^\d+$/.test(lines[0].trim())) idx = 1;
+    if (idx >= lines.length) continue;
+    const times = parseTimeRange(lines[idx]);
+    if (!times) continue;
+    const body = lines.slice(idx + 1).join("\n");
+    const { text: cueText, speaker } = stripCueMeta(body);
+    if (!cueText) continue;
+    cues.push({ ...times, text: cueText, speaker });
+  }
+  return cues;
+}
+
+function parseVtt(text: string): Cue[] {
+  let body = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  // Drop header + optional metadata until the first blank line after WEBVTT.
+  body = body.replace(/^WEBVTT[^\n]*\n(?:.*\n)*?(?=\n)/i, "");
+  const blocks = body.split(/\n\n+/);
+  const cues: Cue[] = [];
+  for (const block of blocks) {
+    const lines = block
+      .split("\n")
+      .map((l) => l.trimEnd())
+      .filter((l) => l.length > 0 && !l.startsWith("NOTE"));
+    if (lines.length === 0) continue;
+    let idx = 0;
+    // Optional cue identifier line before the arrow.
+    if (!parseTimeRange(lines[0])) {
+      if (lines.length < 2 || !parseTimeRange(lines[1])) continue;
+      idx = 1;
+    }
+    const times = parseTimeRange(lines[idx]);
+    if (!times) continue;
+    const raw = lines.slice(idx + 1).join("\n");
+    const { text: cueText, speaker } = stripCueMeta(raw);
+    if (!cueText) continue;
+    cues.push({ ...times, text: cueText, speaker });
+  }
+  return cues;
+}
+
+/** `00:00:01,000 --> 00:00:04,000` or `00:01.000 --> 00:04.000` (± cue settings). */
+function parseTimeRange(line: string): { start: number; end: number } | null {
+  const m = line.match(
+    /^(\d{1,2}:)?\d{1,2}:\d{2}[,.]\d{1,3}\s*-->\s*(\d{1,2}:)?\d{1,2}:\d{2}[,.]\d{1,3}/
+  );
+  if (!m) return null;
+  const parts = line.split(/\s*-->\s*/);
+  if (parts.length < 2) return null;
+  const start = parseTimestamp(parts[0].trim());
+  // End may have cue settings after it ("align:start position:0%").
+  const endToken = parts[1].trim().split(/\s+/)[0];
+  const end = parseTimestamp(endToken);
+  if (start === null || end === null) return null;
+  return { start, end: Math.max(end, start + 0.02) };
+}
+
+function parseTimestamp(raw: string): number | null {
+  const t = raw.trim().replace(",", ".");
+  const parts = t.split(":");
+  if (parts.length < 2 || parts.length > 3) return null;
+  const sec = Number(parts[parts.length - 1]);
+  const min = Number(parts[parts.length - 2]);
+  const hr = parts.length === 3 ? Number(parts[0]) : 0;
+  if (![sec, min, hr].every(Number.isFinite)) return null;
+  return hr * 3600 + min * 60 + sec;
+}
+
+function stripCueMeta(raw: string): { text: string; speaker?: string } {
+  let text = raw
+    // VTT voice spans: <v Speaker>…</v> or <v Speaker>…
+    .replace(/<\/?c[^>]*>/gi, "")
+    .replace(/<\/?b>/gi, "")
+    .replace(/<\/?i>/gi, "")
+    .replace(/<\/?u>/gi, "");
+
+  let speaker: string | undefined;
+  const voiceOpen = text.match(/^<v(?:\.[^\s>]*)?\s+([^>]+)>([\s\S]*)$/i);
+  if (voiceOpen) {
+    speaker = voiceOpen[1].trim();
+    text = voiceOpen[2].replace(/<\/v>\s*$/i, "");
+  } else {
+    // Strip any remaining tags; capture leading "Name: " speaker labels.
+    text = text.replace(/<[^>]+>/g, "");
+    const labeled = text.match(/^([A-Za-z][\w\s'-]{0,40}):\s+([\s\S]+)$/);
+    if (labeled) {
+      speaker = labeled[1].trim();
+      text = labeled[2];
+    }
+  }
+
+  text = text
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+  return { text, speaker };
+}
+
+function wordsFromCues(cues: Cue[]): Word[] {
+  const speakerIds = new Map<string, number>();
+  let nextSpeaker = 0;
+  const words: Word[] = [];
+  let id = 0;
+
+  for (const cue of cues) {
+    const tokens = cue.text.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) continue;
+
+    let speaker = 0;
+    if (cue.speaker) {
+      if (!speakerIds.has(cue.speaker)) speakerIds.set(cue.speaker, nextSpeaker++);
+      speaker = speakerIds.get(cue.speaker)!;
+    }
+
+    const span = Math.max(0.02, cue.end - cue.start);
+    const totalChars = tokens.reduce((n, t) => n + t.length, 0) || tokens.length;
+    let cursor = cue.start;
+    for (let i = 0; i < tokens.length; i++) {
+      const t = tokens[i];
+      const dur = (span * t.length) / totalChars;
+      const end =
+        i === tokens.length - 1 ? cue.end : Math.min(cue.end, cursor + dur);
+      words.push({
+        id: id++,
+        text: t,
+        start: cursor,
+        end: Math.max(cursor + 0.02, end),
+        speaker,
+        deleted: false,
+      });
+      cursor = end;
+    }
+  }
+  return words;
+}

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ModelChoice } from "./models";
+import { isModelChoice } from "./models";
 import type { MediaKind } from "./media";
 import type { Word } from "./types";
 
@@ -119,7 +120,7 @@ export async function putProject(input: ProjectWrite): Promise<string> {
     name: input.name,
     mediaKind: input.mediaKind,
     duration: input.duration,
-    model: input.model,
+    model: isModelChoice(input.model) ? input.model : "base",
     words: input.words,
     showDeleted: input.showDeleted,
     media: input.media,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -54,7 +54,8 @@ interface EditorState {
   exportOpen: boolean;
 
   // Actions
-  loadVideo: (file: File) => void;
+  /** Load media for editing. Pass `words` to skip Whisper and use that transcript. */
+  loadVideo: (file: File, options?: { words?: Word[] }) => void;
   /** Restore a saved project from IndexedDB (no re-transcription). */
   openProject: (id: string) => Promise<void>;
   /** Delete a saved project; if it is the active one, resets to the home screen. */
@@ -67,6 +68,11 @@ interface EditorState {
   setPartialText: (t: string) => void;
   setError: (message: string) => void;
   setWords: (words: Word[]) => void;
+  /**
+   * Replace the current transcript with an imported one (keeps media).
+   * Used when the user brings their own SRT/VTT/JSON instead of Whisper.
+   */
+  importWords: (words: Word[]) => void;
   deleteWords: (ids: number[]) => void;
   restoreWords: (ids: number[]) => void;
   /** Replace the selected (contiguous) words with corrected text. */
@@ -114,9 +120,11 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   exportUrl: null,
   exportOpen: false,
 
-  loadVideo: (file) => {
+  loadVideo: (file, options) => {
     const kind = detectMediaKind(file);
     if (!kind) return;
+    const imported = options?.words;
+    if (imported && imported.length === 0) return;
     const prev = get().mediaUrl;
     if (prev) URL.revokeObjectURL(prev);
     set({
@@ -124,10 +132,13 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       mediaUrl: URL.createObjectURL(file),
       mediaKind: kind,
       projectId: null,
-      skipTranscription: false,
+      skipTranscription: Boolean(imported),
       status: "preparing",
-      progress: { message: "Loading media engine…", value: null },
-      words: [],
+      progress: {
+        message: imported ? "Loading media…" : "Loading media engine…",
+        value: null,
+      },
+      words: imported ? imported : [],
       past: [],
       future: [],
       partialText: "",
@@ -195,6 +206,30 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   setWords: (words) => {
     set({ words, past: [], future: [] });
     if (get().status === "ready") bumpAutosave();
+  },
+  importWords: (words) => {
+    if (words.length === 0) return;
+    const { status } = get();
+    if (
+      status !== "ready" &&
+      status !== "error" &&
+      status !== "transcribing"
+    ) {
+      return;
+    }
+    // Stop Whisper if it was still running.
+    void import("@/hooks/useTranscriber").then((m) => m.cancelTranscription());
+    set({
+      words,
+      past: [],
+      future: [],
+      partialText: "",
+      error: null,
+      status: "ready",
+      progress: { message: "", value: null },
+      skipTranscription: true,
+    });
+    bumpAutosave();
   },
 
   deleteWords: (ids) => {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -2,8 +2,13 @@
 
 import { create } from "zustand";
 import type { EditorStatus, ProgressInfo, Word } from "./types";
+import {
+  isModelChoice,
+  isWhisperModel,
+  loadModelPreference,
+  saveModelPreference,
+} from "./models";
 import type { ModelChoice } from "./models";
-import { loadModelPreference, saveModelPreference } from "./models";
 import { detectMediaKind, type MediaKind } from "./media";
 import {
   deleteProject,
@@ -11,6 +16,11 @@ import {
   getProject,
   type ProjectMeta,
 } from "./projects";
+
+interface PendingTranscript {
+  name: string;
+  words: Word[];
+}
 
 interface EditorState {
   // Media
@@ -21,13 +31,18 @@ interface EditorState {
   duration: number;
   /** Mono 16 kHz PCM of the media's audio track (used for waveform + ASR). */
   audio: Float32Array | null;
-  /** Transcription model selected on the upload screen. */
+  /** Transcript source selected on the upload screen (Whisper or import). */
   model: ModelChoice;
+  /**
+   * Caption file parsed on the upload screen when source is "import".
+   * Cleared when switching back to a Whisper model or after media loads.
+   */
+  pendingTranscript: PendingTranscript | null;
   /** IndexedDB project id when this session is persisted; null for a fresh upload mid-pipeline. */
   projectId: string | null;
   /**
    * When true, Editor extracts audio for the waveform but skips Whisper
-   * (restored projects already have words).
+   * (restored projects / imported transcripts already have words).
    */
   skipTranscription: boolean;
 
@@ -61,6 +76,7 @@ interface EditorState {
   /** Delete a saved project; if it is the active one, resets to the home screen. */
   removeProject: (id: string) => Promise<void>;
   setModel: (m: ModelChoice) => void;
+  setPendingTranscript: (t: PendingTranscript | null) => void;
   setDuration: (d: number) => void;
   setAudio: (a: Float32Array) => void;
   setStatus: (s: EditorStatus) => void;
@@ -100,6 +116,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   duration: 0,
   audio: null,
   model: "base",
+  pendingTranscript: null,
   projectId: null,
   skipTranscription: false,
 
@@ -127,12 +144,15 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     if (imported && imported.length === 0) return;
     const prev = get().mediaUrl;
     if (prev) URL.revokeObjectURL(prev);
+    const current = get().model;
     set({
       videoFile: file,
       mediaUrl: URL.createObjectURL(file),
       mediaKind: kind,
       projectId: null,
       skipTranscription: Boolean(imported),
+      model: imported ? "import" : isWhisperModel(current) ? current : "base",
+      pendingTranscript: null,
       status: "preparing",
       progress: {
         message: imported ? "Loading media…" : "Loading media engine…",
@@ -161,9 +181,10 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       mediaUrl: URL.createObjectURL(file),
       mediaKind: record.mediaKind,
       duration: record.duration,
-      model: record.model,
+      model: isModelChoice(record.model) ? record.model : "base",
       projectId: record.id,
       skipTranscription: true,
+      pendingTranscript: null,
       status: "preparing",
       progress: { message: "Loading media engine…", value: null },
       words: record.words,
@@ -188,9 +209,14 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   },
 
   setModel: (model) => {
-    saveModelPreference(model);
-    set({ model });
+    if (isWhisperModel(model)) {
+      saveModelPreference(model);
+      set({ model, pendingTranscript: null });
+    } else {
+      set({ model });
+    }
   },
+  setPendingTranscript: (pendingTranscript) => set({ pendingTranscript }),
   setDuration: (duration) => {
     set({ duration });
     if (get().status === "ready") bumpAutosave();
@@ -228,6 +254,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       status: "ready",
       progress: { message: "", value: null },
       skipTranscription: true,
+      model: "import",
     });
     bumpAutosave();
   },
@@ -343,6 +370,8 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       mediaKind: null,
       duration: 0,
       audio: null,
+      model: loadModelPreference(),
+      pendingTranscript: null,
       projectId: null,
       skipTranscription: false,
       status: "idle",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,7 +51,7 @@ export interface WorkerRequest {
   audio: Float32Array;
   /** Total media duration in seconds (used for progress estimation). */
   duration: number;
-  /** Which transcription model to use (see lib/models.ts). */
-  model: import("./models").ModelChoice;
+  /** Which Whisper model to use (see lib/models.ts). */
+  model: import("./models").WhisperModel;
   language?: string;
 }

--- a/scripts/parse-transcript-test.ts
+++ b/scripts/parse-transcript-test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for SRT / VTT / JSON transcript import.
+ * Run: npx tsx scripts/parse-transcript-test.ts
+ */
+import { parseTranscript } from "../lib/parseTranscript";
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+{
+  const words = parseTranscript(
+    `1
+00:00:01,000 --> 00:00:03,000
+Hello world
+
+2
+00:00:04,500 --> 00:00:06,000
+Alice: How are you?
+`,
+    "sample.srt"
+  );
+  assert(words.length === 5, `srt expected 5 words, got ${words.length}`);
+  assert(words[0].text === "Hello", "srt first word");
+  assert(words[0].start === 1, `srt start ${words[0].start}`);
+  assert(words[1].text === "world", "srt second word");
+  assert(Math.abs(words[1].end - 3) < 1e-6, "srt cue end on last token");
+  assert(words[2].text === "How", "srt speaker label stripped");
+  assert(words[2].speaker === 0, "srt Name: maps to speaker 0");
+  console.log("srt: ok");
+}
+
+{
+  const words = parseTranscript(
+    `WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+<v Ned>Winter is coming
+
+00:00:02.500 --> 00:00:04.000
+<v Catelyn>You know nothing
+`,
+    "sample.vtt"
+  );
+  assert(words.length === 6, `vtt expected 6 words, got ${words.length}`);
+  assert(words[0].speaker === 0 && words[0].text === "Winter", "vtt voice 0");
+  assert(words[3].speaker === 1 && words[3].text === "You", "vtt voice 1");
+  console.log("vtt: ok");
+}
+
+{
+  const words = parseTranscript(
+    JSON.stringify({
+      words: [
+        { text: "One", start: 0, end: 0.4, speaker: "A" },
+        { text: "Two", start: 0.4, end: 0.8, speaker: "B" },
+      ],
+    }),
+    "sample.json"
+  );
+  assert(words.length === 2, "json length");
+  assert(words[0].speaker === 0 && words[1].speaker === 1, "json speakers");
+  console.log("json: ok");
+}
+
+{
+  let threw = false;
+  try {
+    parseTranscript("   ", "empty.srt");
+  } catch {
+    threw = true;
+  }
+  assert(threw, "empty should throw");
+  console.log("empty: ok");
+}
+
+console.log("ALL PARSE TRANSCRIPT TESTS PASSED");

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -21,7 +21,7 @@ import {
   type AutomaticSpeechRecognitionPipeline,
 } from "@huggingface/transformers";
 import type { Word, WorkerRequest, WorkerResponse } from "@/lib/types";
-import { MODELS, type ModelChoice } from "@/lib/models";
+import { MODELS, type WhisperModel } from "@/lib/models";
 import { cleanTranscript } from "@/lib/hallucinations";
 import {
   VAD_FRAME_SIZE,
@@ -140,7 +140,7 @@ async function pickDevice(): Promise<"webgpu" | "wasm"> {
 
 // Keyed by model id so choices that share weights reuse one pipeline.
 const asrPromises = new Map<string, Promise<AutomaticSpeechRecognitionPipeline>>();
-async function getAsr(choice: ModelChoice) {
+async function getAsr(choice: WhisperModel) {
   const { id, dtype } = MODELS[choice];
   let promise = asrPromises.get(id);
   if (!promise) {
@@ -418,7 +418,7 @@ function assignSpeakers(words: Word[], segments: DiarizationSegment[]) {
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
   const { audio, duration, model, language } = event.data;
   try {
-    const choice = model ?? "base";
+    const choice: WhisperModel = model ?? "base";
 
     // Overlap Whisper + Silero downloads; diarizer warms in the background.
     getDiarizer().catch(() => {});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users can bring their own transcript instead of running Whisper.

### Upload screen — transcript source menu

The header control is a **generic `ModelSelector`** that takes option components as children (defaults to Whisper Base / Small). Upload composes:

```tsx
<ModelSelector groupLabel="Transcript source">
  <ModelOption id="base" />
  <ModelOption id="small" />
  <ModelOptionSeparator />
  <ImportTranscriptOption />
</ModelSelector>
```

**Import transcript** opens an SRT / VTT / JSON picker; parse status and errors stay on that option row (and the closed trigger). Drop media afterward to edit with those timings.

### Editor

**Import** in the transcript toolbar still replaces the current transcript and cancels in-flight Whisper if needed.

### Parsing (`lib/parseTranscript.ts`)

- **SRT** / **WebVTT** → cue text split into words; time span distributed by character length
- **JSON** → `Word[]` or `{ "words": [...] }`
- Speakers from VTT `<v Name>` tags, `Name:` prefixes, or JSON `speaker` fields

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

