### PR TITLE
Fix import selector stuck state after cancel

### DIFF
--- a/components/ImportTranscriptOption.tsx
+++ b/components/ImportTranscriptOption.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FileText, Loader2 } from "lucide-react";
-import { loadModelPreference } from "@/lib/models";
 import {
   isTranscriptFile,
   parseTranscriptFile,
   TRANSCRIPT_ACCEPT,
 } from "@/lib/parseTranscript";
+import { isWhisperModel } from "@/lib/models";
 import { useEditorStore } from "@/lib/store";
 import {
   ModelOption,
@@ -19,18 +19,64 @@ import {
 /**
  * ModelSelector option that opens a caption file picker and surfaces parse
  * status / errors on the row (and in the closed trigger).
+ *
+ * Do not set model to "import" until a file is successfully parsed (or we
+ * have a concrete error to show). Native file-picker cancel often does not
+ * fire onChange — previously `select()` ran first, then the menu unmounted
+ * and dropped the custom trigger, leaving the closed button stuck on the
+ * literal label "import" with the default wave icon. That same stuck
+ * `model === "import"` (with no pending file) is what made media drops
+ * complain about choosing a transcript while the UI looked like Whisper.
  */
 export default function ImportTranscriptOption() {
   const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
   const setPendingTranscript = useEditorStore((s) => s.setPendingTranscript);
   const setModel = useEditorStore((s) => s.setModel);
+  const selected = useEditorStore((s) => s.model === "import");
   const [reading, setReading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [picking, setPicking] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<Pick<
     ModelOptionContextValue,
     "keepMenuOpen" | "select"
   > | null>(null);
+  const previousModelRef = useRef<"base" | "small">("base");
+  const pickGenRef = useRef(0);
+
+  // If the user switches to Whisper while a picker/parse is in flight, invalidate
+  // so a late onChange/parse cannot flip model back to import.
+  useEffect(() => {
+    return useEditorStore.subscribe((state, prev) => {
+      if (!isWhisperModel(state.model) || state.model === prev.model) return;
+      pickGenRef.current += 1;
+      queueMicrotask(() => {
+        setPicking(false);
+        setReading(false);
+        setError(null);
+      });
+    });
+  }, []);
+
+  // If the OS file dialog is cancelled, onChange often never fires. When focus
+  // returns without a successful pick, clear the transient picking state and
+  // ensure we are not left on import without a transcript.
+  useEffect(() => {
+    if (!picking) return;
+    const gen = pickGenRef.current;
+    const onFocus = () => {
+      window.setTimeout(() => {
+        if (pickGenRef.current !== gen) return;
+        setPicking(false);
+        const state = useEditorStore.getState();
+        if (state.model === "import" && !state.pendingTranscript) {
+          setModel(previousModelRef.current);
+        }
+      }, 400);
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [picking, setModel]);
 
   const triggerLabel = reading
     ? "Import…"
@@ -39,6 +85,12 @@ export default function ImportTranscriptOption() {
       : pendingTranscript
         ? pendingTranscript.name
         : "Import transcript";
+
+  // Keep the custom trigger registered whenever import owns (or is about to
+  // own) the closed button — otherwise ModelSelector falls back to the raw id
+  // "import" + AudioLines.
+  const triggerEnabled =
+    selected || picking || reading || Boolean(error) || Boolean(pendingTranscript);
 
   return (
     <ModelOption
@@ -49,7 +101,13 @@ export default function ImportTranscriptOption() {
       autoTrigger={false}
       onSelect={(ctx) => {
         menuRef.current = ctx;
-        ctx.select();
+        const current = useEditorStore.getState().model;
+        if (isWhisperModel(current)) {
+          previousModelRef.current = current;
+        }
+        // Do not set model to "import" until parse succeeds (or errors).
+        pickGenRef.current += 1;
+        setPicking(true);
         setError(null);
         ctx.keepMenuOpen();
         requestAnimationFrame(() => fileRef.current?.click());
@@ -59,6 +117,7 @@ export default function ImportTranscriptOption() {
         label={triggerLabel}
         busy={reading}
         error={Boolean(error)}
+        enabled={triggerEnabled}
       />
       <input
         ref={fileRef}
@@ -71,16 +130,20 @@ export default function ImportTranscriptOption() {
           void (async () => {
             const file = files?.[0];
             const menu = menuRef.current;
+            const gen = ++pickGenRef.current; // invalidate focus-cancel timer
             if (!file) {
-              if (!pendingTranscript) {
-                setError(null);
-                setModel(loadModelPreference());
+              setPicking(false);
+              setError(null);
+              if (!useEditorStore.getState().pendingTranscript) {
+                setModel(previousModelRef.current);
               }
               return;
             }
             if (!isTranscriptFile(file)) {
+              setPicking(false);
               setError("Choose an SRT, VTT, or JSON file.");
               setPendingTranscript(null);
+              setModel("import");
               menu?.keepMenuOpen();
               return;
             }
@@ -89,10 +152,13 @@ export default function ImportTranscriptOption() {
             menu?.keepMenuOpen();
             try {
               const words = await parseTranscriptFile(file);
+              if (pickGenRef.current !== gen) return;
               setPendingTranscript({ name: file.name, words });
-              menu?.select();
+              setModel("import");
+              setPicking(false);
               menu?.keepMenuOpen();
             } catch (err) {
+              if (pickGenRef.current !== gen) return;
               console.error(err);
               setPendingTranscript(null);
               setError(
@@ -100,15 +166,16 @@ export default function ImportTranscriptOption() {
                   ? err.message
                   : "Could not read that transcript."
               );
-              menu?.select();
+              setModel("import");
+              setPicking(false);
               menu?.keepMenuOpen();
             } finally {
-              setReading(false);
+              if (pickGenRef.current === gen) setReading(false);
             }
           })();
         }}
       />
-      <ImportStatus reading={reading} error={error} />
+      <ImportStatus reading={reading} error={error} picking={picking} />
     </ModelOption>
   );
 }
@@ -117,30 +184,39 @@ function ImportTrigger({
   label,
   busy,
   error,
+  enabled,
 }: {
   label: string;
   busy: boolean;
   error: boolean;
+  enabled: boolean;
 }) {
-  useOptionTrigger("import", {
-    label,
-    icon: FileText,
-    iconClassName: error ? "text-red-500" : "text-zinc-500",
-    busy,
-  });
+  useOptionTrigger(
+    "import",
+    {
+      label,
+      icon: FileText,
+      iconClassName: error ? "text-red-500" : "text-zinc-500",
+      busy,
+    },
+    enabled
+  );
   return null;
 }
 
 function ImportStatus({
   reading,
   error,
+  picking,
 }: {
   reading: boolean;
   error: string | null;
+  picking: boolean;
 }) {
   const { selected } = useModelOption();
   const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
-  if (!selected || (!reading && !pendingTranscript && !error)) return null;
+  if (!picking && !selected && !reading && !error) return null;
+  if (!reading && !pendingTranscript && !error && !picking) return null;
   return (
     <span
       className={`pl-[1.625rem] text-[11px] leading-snug ${
@@ -156,6 +232,8 @@ function ImportStatus({
         error
       ) : pendingTranscript ? (
         `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
+      ) : picking ? (
+        "Choose an SRT, VTT, or JSON file…"
       ) : null}
     </span>
   );

--- a/components/ModelSelector.tsx
+++ b/components/ModelSelector.tsx
@@ -11,7 +11,13 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { AudioLines, ChevronDown, Loader2, type LucideIcon } from "lucide-react";
+import {
+  AudioLines,
+  ChevronDown,
+  FileText,
+  Loader2,
+  type LucideIcon,
+} from "lucide-react";
 import { MODELS, isWhisperModel, type ModelChoice } from "@/lib/models";
 import { hydrateModelPreference, useEditorStore } from "@/lib/store";
 
@@ -46,6 +52,14 @@ type SelectorContextValue = {
 const ModelSelectorCtx = createContext<SelectorContextValue | null>(null);
 const OptionCtx = createContext<ModelOptionContextValue | null>(null);
 
+function useSelectorCtx(): SelectorContextValue {
+  const ctx = useContext(ModelSelectorCtx);
+  if (!ctx) {
+    throw new Error("Model option components must be used inside ModelSelector");
+  }
+  return ctx;
+}
+
 export function useModelOption(): ModelOptionContextValue {
   const ctx = useContext(OptionCtx);
   if (!ctx) {
@@ -73,6 +87,8 @@ export function useOptionTrigger(
  * Generic source / model dropdown. Pass option components as children
  * (`ModelOption`, or a custom option like `ImportTranscriptOption`).
  * With no children, renders the default Whisper Base / Small rows.
+ *
+ * Options stay mounted (hidden when closed) so custom triggers remain registered.
  */
 export default function ModelSelector({
   children,
@@ -149,11 +165,19 @@ export default function ModelSelector({
   );
 
   const activeTrigger = triggers[model];
-  const TriggerIcon = activeTrigger?.icon ?? AudioLines;
+  // Prefer the option's registered trigger. Fall back carefully so an unmounted
+  // custom option (e.g. import) never shows the raw id + default wave icon.
+  const TriggerIcon =
+    activeTrigger?.icon ?? (model === "import" ? FileText : AudioLines);
   const triggerLabel =
     activeTrigger?.label ??
-    (isWhisperModel(model) ? MODELS[model].label : model);
+    (isWhisperModel(model)
+      ? MODELS[model].label
+      : model === "import"
+        ? "Import transcript"
+        : String(model));
 
+  // Always mount options (hidden when closed) so custom triggers stay registered.
   const options = children ?? (
     <>
       <ModelOption id="base" />
@@ -187,30 +211,21 @@ export default function ModelSelector({
           />
         </button>
 
-        {open && (
-          <div
-            id={listId}
-            role="listbox"
-            aria-label={groupLabel}
-            className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
-          >
-            <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
-              {groupLabel}
-            </p>
-            <div className="p-1 pb-1.5">{options}</div>
-          </div>
-        )}
+        <div
+          id={listId}
+          role="listbox"
+          aria-label={groupLabel}
+          hidden={!open}
+          className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
+        >
+          <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
+            {groupLabel}
+          </p>
+          <div className="p-1 pb-1.5">{options}</div>
+        </div>
       </div>
     </ModelSelectorCtx.Provider>
   );
-}
-
-function useSelectorCtx(): SelectorContextValue {
-  const ctx = useContext(ModelSelectorCtx);
-  if (!ctx) {
-    throw new Error("Model option components must be used inside ModelSelector");
-  }
-  return ctx;
 }
 
 /** Default option row: icon + label + optional meta. Whisper ids fill in from MODELS. */
@@ -228,9 +243,7 @@ export function ModelOption({
   label?: string;
   meta?: string;
   icon?: LucideIcon;
-  /** Extra content under the main row (status, errors, …). */
   children?: ReactNode;
-  /** Override click handling. Defaults to set value + close. */
   onSelect?: (ctx: ModelOptionContextValue) => void;
   autoTrigger?: boolean;
 }) {
@@ -253,11 +266,7 @@ export function ModelOption({
     [selector, selected, id]
   );
 
-  useOptionTrigger(
-    id,
-    { label: resolvedLabel, icon: Icon },
-    autoTrigger
-  );
+  useOptionTrigger(id, { label: resolvedLabel, icon: Icon }, autoTrigger);
 
   const handleClick = () => {
     if (onSelect) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes two related bugs after the transcript-import selector landed:

1. **Cancel file picker** could leave the closed trigger showing the literal label `import` with the default wave (`AudioLines`) icon.
2. **Drop media** could alert “choose a transcript first” even when the UI looked like Whisper Base/Small was selected.

## Cause
Selecting Import called `select()` immediately (setting `model` to `"import"`) before a file was chosen. Cancelling the native picker often skips `onChange`, so the store stayed on `import` with no pending transcript. Closing the menu also unmounted options and unregistered the custom FileText trigger, so the button fell back to `String(model)` + `AudioLines`.

## Fix
- Do not set `model` to `"import"` until a transcript parses successfully (or we have a concrete parse/type error).
- On cancel (empty `onChange` or focus return with no pick), restore the previous Whisper model.
- Keep selector options mounted (`hidden` when closed) so custom triggers stay registered.
- Defensive closed-trigger fallback for `import` (FileText + “Import transcript”).
- Invalidate in-flight picks if the user switches back to Whisper mid-dialog/parse.

## Test plan
- [ ] Open source menu → Import transcript → cancel the file dialog → closed button still shows Whisper Base/Small (previous choice), not `import` + wave icon.
- [ ] Cancel import, then drop media → Whisper transcription starts (no “choose a transcript” alert).
- [ ] Import a valid SRT/VTT/JSON → trigger shows filename + FileText; drop media uses that transcript.
- [ ] Start import, switch to Base/Small before finishing → stays on Whisper; late file selection does not flip back to import.
- [ ] Import an invalid file → error stays on the Import row; can retry or switch to Whisper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

