### PR TITLE
Fix model selector not reopening after import cancel

### DIFF
--- a/components/ImportTranscriptOption.tsx
+++ b/components/ImportTranscriptOption.tsx
@@ -20,10 +20,11 @@ import {
  * ModelSelector option that opens a caption file picker and surfaces parse
  * status / errors on the row (and in the closed trigger).
  *
- * Do not set model to "import" until a file is chosen. Native file-picker
- * cancel often skips onChange — we close the menu before opening the picker
- * and restore the previous Whisper model on cancel so the dropdown cannot
- * get stuck open on a half-selected import.
+ * The file input must NOT be nested inside the option <button> — that invalid
+ * HTML makes some browsers stop delivering clicks to the selector after the
+ * OS dialog is cancelled. Cancel also must not call closeMenu(): the menu is
+ * already closed before the picker opens, and a delayed close would dismiss a
+ * menu the user just reopened.
  */
 export default function ImportTranscriptOption() {
   const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
@@ -41,6 +42,7 @@ export default function ImportTranscriptOption() {
   const previousModelRef = useRef<"base" | "small">("base");
   const pickGenRef = useRef(0);
 
+  /** Reset import-pick state only — never touch the dropdown open state. */
   const finishCancel = useCallback(() => {
     setPicking(false);
     setReading(false);
@@ -48,7 +50,6 @@ export default function ImportTranscriptOption() {
     if (!useEditorStore.getState().pendingTranscript) {
       setModel(previousModelRef.current);
     }
-    menuRef.current?.closeMenu();
   }, [setModel]);
 
   // If the user switches to Whisper while a picker/parse is in flight, invalidate
@@ -106,38 +107,43 @@ export default function ImportTranscriptOption() {
     selected || picking || reading || Boolean(error) || Boolean(pendingTranscript);
 
   return (
-    <ModelOption
-      id="import"
-      label="Import transcript"
-      meta="SRT / VTT / JSON"
-      icon={FileText}
-      autoTrigger={false}
-      onSelect={(ctx) => {
-        menuRef.current = ctx;
-        const current = useEditorStore.getState().model;
-        if (isWhisperModel(current)) {
-          previousModelRef.current = current;
-        }
-        // Do not set model to "import" until a file is chosen. Close the menu
-        // before the OS dialog so cancel cannot leave it pinned open.
-        pickGenRef.current += 1;
-        setPicking(true);
-        setError(null);
-        ctx.closeMenu();
-        requestAnimationFrame(() => fileRef.current?.click());
-      }}
-    >
-      <ImportTrigger
-        label={triggerLabel}
-        busy={reading}
-        error={Boolean(error)}
-        enabled={triggerEnabled}
-      />
+    <>
+      <ModelOption
+        id="import"
+        label="Import transcript"
+        meta="SRT / VTT / JSON"
+        icon={FileText}
+        autoTrigger={false}
+        onSelect={(ctx) => {
+          menuRef.current = ctx;
+          const current = useEditorStore.getState().model;
+          if (isWhisperModel(current)) {
+            previousModelRef.current = current;
+          }
+          // Do not set model to "import" until a file is chosen. Close the menu
+          // before the OS dialog so cancel cannot leave it pinned open.
+          pickGenRef.current += 1;
+          setPicking(true);
+          setError(null);
+          ctx.closeMenu();
+          requestAnimationFrame(() => fileRef.current?.click());
+        }}
+      >
+        <ImportTrigger
+          label={triggerLabel}
+          busy={reading}
+          error={Boolean(error)}
+          enabled={triggerEnabled}
+        />
+        <ImportStatus reading={reading} error={error} picking={picking} />
+      </ModelOption>
+      {/* Sibling of the option button — never nest <input> inside <button>. */}
       <input
         ref={fileRef}
         type="file"
         accept={TRANSCRIPT_ACCEPT}
-        className="hidden"
+        tabIndex={-1}
+        className="sr-only"
         onChange={(e) => {
           const files = e.target.files;
           e.target.value = "";
@@ -184,8 +190,7 @@ export default function ImportTranscriptOption() {
           })();
         }}
       />
-      <ImportStatus reading={reading} error={error} picking={picking} />
-    </ModelOption>
+    </>
   );
 }
 

--- a/components/ModelSelector.tsx
+++ b/components/ModelSelector.tsx
@@ -110,19 +110,16 @@ export default function ModelSelector({
 
   useEffect(() => {
     if (!open) return;
-    const onPointer = (e: PointerEvent | MouseEvent) => {
+    const onPointer = (e: PointerEvent) => {
       if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
     };
-    // pointerdown covers mouse + touch; mousedown kept for older engines.
     document.addEventListener("pointerdown", onPointer);
-    document.addEventListener("mousedown", onPointer);
     document.addEventListener("keydown", onKey);
     return () => {
       document.removeEventListener("pointerdown", onPointer);
-      document.removeEventListener("mousedown", onPointer);
       document.removeEventListener("keydown", onKey);
     };
   }, [open]);
@@ -219,7 +216,12 @@ export default function ModelSelector({
           role="listbox"
           aria-label={groupLabel}
           hidden={!open}
-          className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5"
+          // Force display:none when closed so a lingering panel cannot eat clicks
+          // (HTML [hidden] can be overridden by author CSS in some setups).
+          className={`absolute right-0 top-[calc(100%+0.5rem)] z-20 w-[18rem] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg shadow-zinc-900/5 ${
+            open ? "" : "pointer-events-none"
+          }`}
+          style={open ? undefined : { display: "none" }}
         >
           <p className="px-3 pb-1 pt-2.5 text-[11px] font-medium tracking-wide text-zinc-400">
             {groupLabel}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After Import → cancel file dialog, the source selector trigger stopped responding (clicks appeared to do nothing).

## Cause
1. The transcript `<input type="file">` was rendered **inside** the option `<button>` (invalid HTML). After the OS dialog is cancelled, some browsers stop delivering clicks cleanly around that control.
2. The delayed cancel fallback called `closeMenu()`, so if you reopened the menu within ~400ms it was immediately closed again — which feels like the trigger is dead.

## Fix
- Render the file input as a **sibling** of the option row, not a child of the button
- On cancel, only reset import/pick state (restore Whisper) — do **not** touch dropdown open state (menu is already closed before the picker opens)
- Harden the closed listbox so it cannot intercept clicks (`display: none` + `pointer-events-none`)

## Test plan
- [ ] Open source menu → Import transcript → cancel the file dialog → Whisper stays selected, menu stays closed
- [ ] Click the source trigger again → menu opens normally
- [ ] Open/close repeatedly (outside click, Escape, trigger) still works
- [ ] Successful SRT/VTT/JSON import still works; invalid file still shows an error

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

