### PR TITLE
Sync plain-text transcripts to audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the media. Export the final cut — without your file ever leaving your device.
 
 - 🔒 **Private by design** — no server, no auth, no uploads; all media processing happens on-device
 - 📝 **Word-level editing** — select words, press ⌫, the cut follows the text
-- 📥 **Import your own transcript** — skip Whisper and edit with an SRT, VTT, or JSON caption file
+- 📥 **Import your own transcript** — SRT / VTT / JSON with timestamps, or plain TXT synced to the audio
 - 🧹 **Filler removal** — one-click cut of "um", "uh", and similar fillers
 - 🗣️ **Speaker diarization** — the transcript is grouped by speaker
 - 🎬 **Timeline** — waveform, word labels, cut regions, playhead, zoom
@@ -63,7 +63,7 @@ audio track.
 2. **Transcribe** — Whisper runs in a Web Worker with `return_timestamps: "word"`,
    streaming text as it goes; pyannote assigns a speaker to every word.
    Choose **Whisper Base**, **Whisper Small**, or **Import transcript**
-   (SRT / VTT / JSON) on the homepage.
+   (SRT / VTT / JSON / TXT) on the homepage.
 3. **Edit** — deleting words produces "cut ranges" of the original media. The
    preview player skips them in real time and the timeline shows them in red.
    **Remove fillers** cuts every detected "um" / "uh" / etc. in one click.

--- a/components/ImportTranscriptOption.tsx
+++ b/components/ImportTranscriptOption.tsx
@@ -111,7 +111,7 @@ export default function ImportTranscriptOption() {
       <ModelOption
         id="import"
         label="Import transcript"
-        meta="SRT / VTT / JSON"
+        meta="SRT / VTT / JSON / TXT"
         icon={FileText}
         autoTrigger={false}
         onSelect={(ctx) => {
@@ -157,7 +157,7 @@ export default function ImportTranscriptOption() {
             }
             if (!isTranscriptFile(file)) {
               setPicking(false);
-              setError("Choose an SRT, VTT, or JSON file.");
+              setError("Choose an SRT, VTT, JSON, or TXT file.");
               setPendingTranscript(null);
               setModel("import");
               menu?.keepMenuOpen();
@@ -168,9 +168,21 @@ export default function ImportTranscriptOption() {
             setError(null);
             setModel("import"); // so the closed trigger can show progress
             try {
-              const words = await parseTranscriptFile(file);
+              const parsed = await parseTranscriptFile(file);
               if (pickGenRef.current !== gen) return;
-              setPendingTranscript({ name: file.name, words });
+              if (parsed.kind === "timed") {
+                setPendingTranscript({
+                  name: file.name,
+                  kind: "timed",
+                  words: parsed.words,
+                });
+              } else {
+                setPendingTranscript({
+                  name: file.name,
+                  kind: "untimed",
+                  tokens: parsed.tokens,
+                });
+              }
               setModel("import");
               menu?.closeMenu();
             } catch (err) {
@@ -245,9 +257,11 @@ function ImportStatus({
       ) : error ? (
         error
       ) : pendingTranscript ? (
-        `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
+        pendingTranscript.kind === "timed"
+          ? `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
+          : `${pendingTranscript.name} · ${pendingTranscript.tokens.length} words · syncs to audio`
       ) : picking ? (
-        "Choose an SRT, VTT, or JSON file…"
+        "Choose an SRT, VTT, JSON, or TXT file…"
       ) : null}
     </span>
   );

--- a/components/ImportTranscriptOption.tsx
+++ b/components/ImportTranscriptOption.tsx
@@ -1,219 +1,90 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { FileText, Loader2 } from "lucide-react";
-import {
-  isTranscriptFile,
-  parseTranscriptFile,
-  TRANSCRIPT_ACCEPT,
-} from "@/lib/parseTranscript";
-import { isWhisperModel } from "@/lib/models";
+import { useCallback, useState } from "react";
+import { FileText } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
+import type { ParsedTranscript } from "@/lib/parseTranscript";
 import {
   ModelOption,
   useModelOption,
   useOptionTrigger,
-  type ModelOptionContextValue,
 } from "./ModelSelector";
+import PasteTranscriptDialog from "./PasteTranscriptDialog";
 
 /**
- * ModelSelector option that opens a caption file picker and surfaces parse
- * status / errors on the row (and in the closed trigger).
- *
- * The file input must NOT be nested inside the option <button> — that invalid
- * HTML makes some browsers stop delivering clicks to the selector after the
- * OS dialog is cancelled. Cancel also must not call closeMenu(): the menu is
- * already closed before the picker opens, and a delayed close would dismiss a
- * menu the user just reopened.
+ * ModelSelector option that opens a paste / file dialog for the user's own
+ * transcript (timed captions or plain text to sync).
  */
 export default function ImportTranscriptOption() {
   const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
   const setPendingTranscript = useEditorStore((s) => s.setPendingTranscript);
   const setModel = useEditorStore((s) => s.setModel);
   const selected = useEditorStore((s) => s.model === "import");
-  const [reading, setReading] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [picking, setPicking] = useState(false);
-  const fileRef = useRef<HTMLInputElement>(null);
-  const menuRef = useRef<Pick<
-    ModelOptionContextValue,
-    "keepMenuOpen" | "closeMenu" | "select"
-  > | null>(null);
-  const previousModelRef = useRef<"base" | "small">("base");
-  const pickGenRef = useRef(0);
 
-  /** Reset import-pick state only — never touch the dropdown open state. */
-  const finishCancel = useCallback(() => {
-    setPicking(false);
-    setReading(false);
-    setError(null);
-    if (!useEditorStore.getState().pendingTranscript) {
-      setModel(previousModelRef.current);
-    }
-  }, [setModel]);
+  const triggerLabel = error
+    ? "Import failed"
+    : pendingTranscript
+      ? pendingTranscript.name
+      : "Import transcript";
 
-  // If the user switches to Whisper while a picker/parse is in flight, invalidate
-  // so a late onChange/parse cannot flip model back to import.
-  useEffect(() => {
-    return useEditorStore.subscribe((state, prev) => {
-      if (!isWhisperModel(state.model) || state.model === prev.model) return;
-      pickGenRef.current += 1;
-      queueMicrotask(() => {
-        setPicking(false);
-        setReading(false);
-        setError(null);
-      });
-    });
-  }, []);
-
-  // Native file-input "cancel" (not in React's input prop types yet).
-  useEffect(() => {
-    const input = fileRef.current;
-    if (!input) return;
-    const onCancel = () => {
-      pickGenRef.current += 1;
-      finishCancel();
-    };
-    input.addEventListener("cancel", onCancel);
-    return () => input.removeEventListener("cancel", onCancel);
-  }, [finishCancel]);
-
-  // Fallback when the OS dialog is cancelled without firing onChange/cancel.
-  useEffect(() => {
-    if (!picking) return;
-    const gen = pickGenRef.current;
-    const onFocus = () => {
-      window.setTimeout(() => {
-        if (pickGenRef.current !== gen) return;
-        finishCancel();
-      }, 400);
-    };
-    window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
-  }, [picking, finishCancel]);
-
-  const triggerLabel = reading
-    ? "Import…"
-    : error
-      ? "Import failed"
-      : pendingTranscript
-        ? pendingTranscript.name
-        : "Import transcript";
-
-  // Keep the custom trigger registered whenever import owns (or is about to
-  // own) the closed button — otherwise ModelSelector falls back to the raw id
-  // "import" + AudioLines.
   const triggerEnabled =
-    selected || picking || reading || Boolean(error) || Boolean(pendingTranscript);
+    selected || Boolean(error) || Boolean(pendingTranscript);
+
+  const handleParsed = useCallback(
+    (parsed: ParsedTranscript, name: string) => {
+      setError(null);
+      if (parsed.kind === "timed") {
+        setPendingTranscript({ name, kind: "timed", words: parsed.words });
+      } else {
+        setPendingTranscript({ name, kind: "untimed", tokens: parsed.tokens });
+      }
+      setModel("import");
+    },
+    [setPendingTranscript, setModel]
+  );
 
   return (
     <>
       <ModelOption
         id="import"
         label="Import transcript"
-        meta="SRT / VTT / JSON / TXT"
+        meta="Paste or file"
         icon={FileText}
         autoTrigger={false}
         onSelect={(ctx) => {
-          menuRef.current = ctx;
-          const current = useEditorStore.getState().model;
-          if (isWhisperModel(current)) {
-            previousModelRef.current = current;
-          }
-          // Do not set model to "import" until a file is chosen. Close the menu
-          // before the OS dialog so cancel cannot leave it pinned open.
-          pickGenRef.current += 1;
-          setPicking(true);
           setError(null);
           ctx.closeMenu();
-          requestAnimationFrame(() => fileRef.current?.click());
+          setDialogOpen(true);
         }}
       >
         <ImportTrigger
           label={triggerLabel}
-          busy={reading}
           error={Boolean(error)}
           enabled={triggerEnabled}
         />
-        <ImportStatus reading={reading} error={error} picking={picking} />
+        <ImportStatus error={error} />
       </ModelOption>
-      {/* Sibling of the option button — never nest <input> inside <button>. */}
-      <input
-        ref={fileRef}
-        type="file"
-        accept={TRANSCRIPT_ACCEPT}
-        tabIndex={-1}
-        className="sr-only"
-        onChange={(e) => {
-          const files = e.target.files;
-          e.target.value = "";
-          void (async () => {
-            const file = files?.[0];
-            const menu = menuRef.current;
-            const gen = ++pickGenRef.current; // invalidate focus-cancel timer
-            if (!file) {
-              finishCancel();
-              return;
-            }
-            if (!isTranscriptFile(file)) {
-              setPicking(false);
-              setError("Choose an SRT, VTT, JSON, or TXT file.");
-              setPendingTranscript(null);
-              setModel("import");
-              menu?.keepMenuOpen();
-              return;
-            }
-            setReading(true);
-            setPicking(false);
-            setError(null);
-            setModel("import"); // so the closed trigger can show progress
-            try {
-              const parsed = await parseTranscriptFile(file);
-              if (pickGenRef.current !== gen) return;
-              if (parsed.kind === "timed") {
-                setPendingTranscript({
-                  name: file.name,
-                  kind: "timed",
-                  words: parsed.words,
-                });
-              } else {
-                setPendingTranscript({
-                  name: file.name,
-                  kind: "untimed",
-                  tokens: parsed.tokens,
-                });
-              }
-              setModel("import");
-              menu?.closeMenu();
-            } catch (err) {
-              if (pickGenRef.current !== gen) return;
-              console.error(err);
-              setPendingTranscript(null);
-              setError(
-                err instanceof Error
-                  ? err.message
-                  : "Could not read that transcript."
-              );
-              setModel("import");
-              menu?.keepMenuOpen();
-            } finally {
-              if (pickGenRef.current === gen) setReading(false);
-            }
-          })();
-        }}
-      />
+      {dialogOpen && (
+        <PasteTranscriptDialog
+          open
+          title="Import transcript"
+          submitLabel="Use transcript"
+          onClose={() => setDialogOpen(false)}
+          onParsed={handleParsed}
+        />
+      )}
     </>
   );
 }
 
 function ImportTrigger({
   label,
-  busy,
   error,
   enabled,
 }: {
   label: string;
-  busy: boolean;
   error: boolean;
   enabled: boolean;
 }) {
@@ -223,46 +94,30 @@ function ImportTrigger({
       label,
       icon: FileText,
       iconClassName: error ? "text-red-500" : "text-zinc-500",
-      busy,
     },
     enabled
   );
   return null;
 }
 
-function ImportStatus({
-  reading,
-  error,
-  picking,
-}: {
-  reading: boolean;
-  error: string | null;
-  picking: boolean;
-}) {
+function ImportStatus({ error }: { error: string | null }) {
   const { selected } = useModelOption();
   const pendingTranscript = useEditorStore((s) => s.pendingTranscript);
-  if (!picking && !selected && !reading && !error) return null;
-  if (!reading && !pendingTranscript && !error && !picking) return null;
+  if (!selected && !error) return null;
+  if (!pendingTranscript && !error) return null;
   return (
     <span
       className={`pl-[1.625rem] text-[11px] leading-snug ${
         error ? "text-red-500" : "text-zinc-500"
       }`}
     >
-      {reading ? (
-        <span className="inline-flex items-center gap-1">
-          <Loader2 size={11} className="animate-spin" />
-          Reading file…
-        </span>
-      ) : error ? (
-        error
-      ) : pendingTranscript ? (
-        pendingTranscript.kind === "timed"
-          ? `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
-          : `${pendingTranscript.name} · ${pendingTranscript.tokens.length} words · syncs to audio`
-      ) : picking ? (
-        "Choose an SRT, VTT, JSON, or TXT file…"
-      ) : null}
+      {error
+        ? error
+        : pendingTranscript
+          ? pendingTranscript.kind === "timed"
+            ? `${pendingTranscript.name} · ${pendingTranscript.words.length} words`
+            : `${pendingTranscript.name} · ${pendingTranscript.tokens.length} words · syncs to audio`
+          : null}
     </span>
   );
 }

--- a/components/PasteTranscriptDialog.tsx
+++ b/components/PasteTranscriptDialog.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { FileUp, X } from "lucide-react";
+import {
+  isTranscriptFile,
+  parseTranscript,
+  parseTranscriptFile,
+  TRANSCRIPT_ACCEPT,
+  type ParsedTranscript,
+} from "@/lib/parseTranscript";
+
+/**
+ * Descript-style paste / file dialog for bringing your own transcript.
+ * Callers receive a parsed timed or untimed transcript plus a display name.
+ */
+export default function PasteTranscriptDialog({
+  open,
+  title = "Import transcript",
+  submitLabel = "Use transcript",
+  onClose,
+  onParsed,
+}: {
+  open: boolean;
+  title?: string;
+  /** Primary button when the textarea has text (e.g. "Sync transcript"). */
+  submitLabel?: string;
+  onClose: () => void;
+  /** Return `false` to keep the dialog open (e.g. user dismissed a confirm). */
+  onParsed: (
+    parsed: ParsedTranscript,
+    name: string
+  ) => void | boolean | Promise<void | boolean>;
+}) {
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const areaRef = useRef<HTMLTextAreaElement>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const t = window.setTimeout(() => areaRef.current?.focus(), 50);
+    return () => window.clearTimeout(t);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, busy, onClose]);
+
+  const applyParsed = useCallback(
+    async (parsed: ParsedTranscript, name: string) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const result = await onParsed(parsed, name);
+        if (result === false) return;
+        onClose();
+      } catch (err) {
+        console.error(err);
+        setError(
+          err instanceof Error ? err.message : "Could not use that transcript."
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [onParsed, onClose]
+  );
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      setError("Paste a transcript, or choose a file.");
+      return;
+    }
+    try {
+      // Empty filename → sniff timed formats, else treat as plain text to sync.
+      const parsed = parseTranscript(trimmed, "");
+      const name =
+        parsed.kind === "untimed" ? "Pasted transcript" : "Pasted captions";
+      void applyParsed(parsed, name);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Could not read that transcript."
+      );
+    }
+  }, [text, applyParsed]);
+
+  const handleFile = useCallback(
+    async (files: FileList | null) => {
+      const file = files?.[0];
+      if (!file) return;
+      if (!isTranscriptFile(file)) {
+        setError("Choose an SRT, VTT, JSON, or TXT file.");
+        return;
+      }
+      setBusy(true);
+      setError(null);
+      try {
+        const parsed = await parseTranscriptFile(file);
+        await applyParsed(parsed, file.name);
+      } catch (err) {
+        console.error(err);
+        setError(
+          err instanceof Error ? err.message : "Could not read that transcript."
+        );
+        setBusy(false);
+      }
+    },
+    [applyParsed]
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/40 p-4 backdrop-blur-sm"
+      onClick={() => !busy && onClose()}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="flex w-full max-w-lg flex-col rounded-2xl bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-zinc-100 px-5 py-4">
+          <h2 id={titleId} className="text-[15px] font-semibold text-zinc-900">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700 disabled:opacity-30"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="px-5 py-4">
+          <p className="mb-3 text-[13px] leading-relaxed text-zinc-500">
+            Paste a plain-text script to sync with your media, or drop in timed
+            captions (SRT / VTT / JSON). Optional speaker labels:{" "}
+            <span className="font-medium text-zinc-600">Name: dialogue</span>
+          </p>
+          <textarea
+            ref={areaRef}
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              if (error) setError(null);
+            }}
+            disabled={busy}
+            rows={10}
+            placeholder={`Alice: Hello there.\nBob: Hi — how are you?`}
+            className="w-full resize-y rounded-xl border border-zinc-200 bg-zinc-50/80 px-3 py-2.5 text-[13px] leading-relaxed text-zinc-800 placeholder:text-zinc-400 outline-none transition focus:border-zinc-400 focus:bg-white focus:ring-2 focus:ring-zinc-900/5 disabled:opacity-60"
+          />
+          {error && (
+            <p className="mt-2 text-[12px] text-red-500" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-zinc-100 px-5 py-3.5">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => fileRef.current?.click()}
+            className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[13px] font-medium text-zinc-600 transition hover:bg-zinc-100 hover:text-zinc-900 disabled:opacity-40"
+          >
+            <FileUp size={14} />
+            Choose file…
+          </button>
+          <input
+            ref={fileRef}
+            type="file"
+            accept={TRANSCRIPT_ACCEPT}
+            className="hidden"
+            onChange={(e) => {
+              const files = e.target.files;
+              e.target.value = "";
+              void handleFile(files);
+            }}
+          />
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={onClose}
+              className="rounded-lg px-3 py-1.5 text-[13px] font-medium text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-800 disabled:opacity-40"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={busy || !text.trim()}
+              onClick={handleSubmit}
+              className="rounded-lg bg-zinc-900 px-3.5 py-1.5 text-[13px] font-medium text-white transition hover:bg-zinc-800 disabled:opacity-40"
+            >
+              {busy ? "Working…" : submitLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -4,12 +4,9 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "
 import { Eye, EyeOff, FileText, Pencil, RotateCcw, Scissors, WandSparkles, X } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import { findFillerWordIds } from "@/lib/fillers";
-import {
-  isTranscriptFile,
-  parseTranscriptFile,
-  TRANSCRIPT_ACCEPT,
-} from "@/lib/parseTranscript";
+import type { ParsedTranscript } from "@/lib/parseTranscript";
 import type { SpeakerTurn, Word } from "@/lib/types";
+import PasteTranscriptDialog from "./PasteTranscriptDialog";
 
 export const SPEAKER_COLORS = [
   "#16a34a", // green
@@ -93,7 +90,7 @@ export default function TranscriptPanel() {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const importInputRef = useRef<HTMLInputElement>(null);
+  const [importOpen, setImportOpen] = useState(false);
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [correcting, setCorrecting] = useState<{
     ids: number[];
@@ -123,53 +120,40 @@ export default function TranscriptPanel() {
     deleteWords(fillerIds);
   }, [deleteWords, fillerIds]);
 
-  const handleImportTranscript = useCallback(
-    async (files: FileList | null) => {
-      const file = files?.[0];
-      if (!file) return;
-      if (!isTranscriptFile(file)) {
-        alert("Please choose an SRT, VTT, JSON, or TXT transcript.");
-        return;
-      }
+  const handleImportParsed = useCallback(
+    async (parsed: ParsedTranscript) => {
       if (
         words.length > 0 &&
-        !confirm("Replace the current transcript with this file?")
+        !confirm("Replace the current transcript with this one?")
       ) {
+        return false;
+      }
+      if (parsed.kind === "timed") {
+        importWords(parsed.words);
         return;
       }
-      try {
-        const parsed = await parseTranscriptFile(file);
-        if (parsed.kind === "timed") {
-          importWords(parsed.words);
-          return;
-        }
-        // Plain text (Descript-style): align to existing timings when we have
-        // them; otherwise run Whisper and sync the reference text onto it.
-        const state = useEditorStore.getState();
-        if (state.words.length > 0) {
-          const { alignTranscript } = await import("@/lib/alignTranscript");
-          const aligned = alignTranscript(
-            parsed.tokens,
-            state.words,
-            state.duration
-          );
-          importWords(aligned);
-          return;
-        }
-        if (!state.audio) {
-          alert("Wait for the media to finish loading, then try again.");
-          return;
-        }
-        state.setSyncTokens(parsed.tokens);
-        const { startTranscription } = await import("@/hooks/useTranscriber");
-        startTranscription(
-          state.audio,
-          state.duration || state.audio.length / 16000
+      // Plain text (Descript-style): align to existing timings when we have
+      // them; otherwise run Whisper and sync the reference text onto it.
+      const state = useEditorStore.getState();
+      if (state.words.length > 0) {
+        const { alignTranscript } = await import("@/lib/alignTranscript");
+        const aligned = alignTranscript(
+          parsed.tokens,
+          state.words,
+          state.duration
         );
-      } catch (err) {
-        console.error(err);
-        alert(err instanceof Error ? err.message : "Could not read that transcript.");
+        importWords(aligned);
+        return;
       }
+      if (!state.audio) {
+        throw new Error("Wait for the media to finish loading, then try again.");
+      }
+      state.setSyncTokens(parsed.tokens);
+      const { startTranscription } = await import("@/hooks/useTranscriber");
+      startTranscription(
+        state.audio,
+        state.duration || state.audio.length / 16000
+      );
     },
     [words.length, importWords]
   );
@@ -358,24 +342,22 @@ export default function TranscriptPanel() {
           {(status === "ready" || status === "error" || status === "transcribing") && (
             <>
               <button
-                onClick={() => importInputRef.current?.click()}
-                title="Replace transcript from SRT, VTT, JSON, or TXT"
+                onClick={() => setImportOpen(true)}
+                title="Paste or import SRT, VTT, JSON, or TXT"
                 className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100"
               >
                 <FileText size={14} />
                 Import
               </button>
-              <input
-                ref={importInputRef}
-                type="file"
-                accept={TRANSCRIPT_ACCEPT}
-                className="hidden"
-                onChange={(e) => {
-                  const files = e.target.files;
-                  e.target.value = "";
-                  void handleImportTranscript(files);
-                }}
-              />
+              {importOpen && (
+                <PasteTranscriptDialog
+                  open
+                  title="Replace transcript"
+                  submitLabel={words.length > 0 ? "Sync transcript" : "Use transcript"}
+                  onClose={() => setImportOpen(false)}
+                  onParsed={handleImportParsed}
+                />
+              )}
             </>
           )}
           <button

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -128,7 +128,7 @@ export default function TranscriptPanel() {
       const file = files?.[0];
       if (!file) return;
       if (!isTranscriptFile(file)) {
-        alert("Please choose an SRT, VTT, or JSON transcript.");
+        alert("Please choose an SRT, VTT, JSON, or TXT transcript.");
         return;
       }
       if (
@@ -138,8 +138,34 @@ export default function TranscriptPanel() {
         return;
       }
       try {
-        const imported = await parseTranscriptFile(file);
-        importWords(imported);
+        const parsed = await parseTranscriptFile(file);
+        if (parsed.kind === "timed") {
+          importWords(parsed.words);
+          return;
+        }
+        // Plain text (Descript-style): align to existing timings when we have
+        // them; otherwise run Whisper and sync the reference text onto it.
+        const state = useEditorStore.getState();
+        if (state.words.length > 0) {
+          const { alignTranscript } = await import("@/lib/alignTranscript");
+          const aligned = alignTranscript(
+            parsed.tokens,
+            state.words,
+            state.duration
+          );
+          importWords(aligned);
+          return;
+        }
+        if (!state.audio) {
+          alert("Wait for the media to finish loading, then try again.");
+          return;
+        }
+        state.setSyncTokens(parsed.tokens);
+        const { startTranscription } = await import("@/hooks/useTranscriber");
+        startTranscription(
+          state.audio,
+          state.duration || state.audio.length / 16000
+        );
       } catch (err) {
         console.error(err);
         alert(err instanceof Error ? err.message : "Could not read that transcript.");
@@ -333,7 +359,7 @@ export default function TranscriptPanel() {
             <>
               <button
                 onClick={() => importInputRef.current?.click()}
-                title="Replace transcript from SRT, VTT, or JSON"
+                title="Replace transcript from SRT, VTT, JSON, or TXT"
                 className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100"
               >
                 <FileText size={14} />

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -30,6 +30,7 @@ import {
   type ProjectMeta,
 } from "@/lib/projects";
 import { useEditorStore } from "@/lib/store";
+import type { AlignToken } from "@/lib/alignTranscript";
 import type { Word } from "@/lib/types";
 
 // The three media cards that stand in for the upload icon. Each carries its
@@ -153,7 +154,10 @@ function RecentProjects({
 export default function UploadScreen({
   onFile,
 }: {
-  onFile: (file: File, options?: { words?: Word[] }) => void;
+  onFile: (
+    file: File,
+    options?: { words?: Word[]; syncTokens?: AlignToken[] }
+  ) => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
@@ -210,7 +214,11 @@ export default function UploadScreen({
           alert("Choose a transcript file from the source menu first.");
           return;
         }
-        onFile(file, { words: pending.words });
+        if (pending.kind === "timed") {
+          onFile(file, { words: pending.words });
+        } else {
+          onFile(file, { syncTokens: pending.tokens });
+        }
         return;
       }
       onFile(file);
@@ -333,7 +341,9 @@ export default function UploadScreen({
               <p className="mt-1 text-[13px] text-zinc-400">
                 {model === "import"
                   ? pendingTranscript
-                    ? `Will use ${pendingTranscript.name} · MP4, WebM, MOV, MP3, WAV, …`
+                    ? pendingTranscript.kind === "timed"
+                      ? `Will use ${pendingTranscript.name} · MP4, WebM, MOV, MP3, WAV, …`
+                      : `Will sync ${pendingTranscript.name} to your media · MP4, WebM, MOV, MP3, WAV, …`
                     : "Pick a transcript in the menu above, then drop your media"
                   : "MP4, WebM, MOV, MP3, WAV, M4A, …"}
               </p>
@@ -366,7 +376,7 @@ export default function UploadScreen({
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
           {[
-            { icon: Type, title: "Transcribe", text: "Whisper locally, or import SRT / VTT." },
+            { icon: Type, title: "Transcribe", text: "Whisper locally, or import SRT / TXT." },
             { icon: Scissors, title: "Edit", text: "Select words and hit delete to edit." },
             { icon: Clapperboard, title: "Export", text: "Render the final cut to MP4 or M4A." },
           ].map(({ icon: Icon, title, text }) => (

--- a/hooks/useTranscriber.ts
+++ b/hooks/useTranscriber.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { isWhisperModel } from "@/lib/models";
+import { alignTranscript } from "@/lib/alignTranscript";
+import { isWhisperModel, loadModelPreference } from "@/lib/models";
 import { useEditorStore } from "@/lib/store";
 import type { WorkerResponse } from "@/lib/types";
 
@@ -13,68 +14,120 @@ export function cancelTranscription() {
   activeWorker = null;
 }
 
+/**
+ * Run Whisper (and optional plain-text sync) against PCM already in the store
+ * pipeline. Shared by the Editor mount path and mid-session TXT import.
+ */
+export function startTranscription(audio: Float32Array, duration: number) {
+  const store = useEditorStore.getState();
+  const syncing = Boolean(store.syncTokens?.length);
+  // Plain-text import keeps model === "import" but still needs Whisper for
+  // timing; use the last Whisper preference for that sync pass.
+  const whisperModel = isWhisperModel(store.model)
+    ? store.model
+    : syncing
+      ? loadModelPreference()
+      : null;
+  if (!whisperModel) {
+    store.setError("Select Whisper Base or Small to transcribe.");
+    return;
+  }
+  store.setStatus("transcribing");
+  store.setProgress({
+    message: syncing
+      ? "Syncing your transcript to the audio…"
+      : "Loading speech model…",
+    value: null,
+  });
+
+  cancelTranscription();
+  const worker = new Worker(
+    new URL("../workers/transcription.worker.ts", import.meta.url),
+    { type: "module" }
+  );
+  activeWorker = worker;
+
+  worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+    const s = useEditorStore.getState();
+    // Timed imports set skipTranscription; ignore late Whisper results.
+    if (s.skipTranscription) return;
+    const msg = event.data;
+    switch (msg.type) {
+      case "progress":
+        s.setProgress({
+          message: s.syncTokens?.length
+            ? msg.message.replace(/^Transcrib/i, "Syncing")
+            : msg.message,
+          value: msg.value,
+        });
+        break;
+      case "partial":
+        s.setPartialText(msg.text);
+        break;
+      case "complete": {
+        const tokens = s.syncTokens;
+        if (tokens && tokens.length > 0) {
+          try {
+            s.setProgress({ message: "Aligning your transcript…", value: 1 });
+            const aligned = alignTranscript(
+              tokens,
+              msg.words,
+              s.duration || duration
+            );
+            s.setSyncTokens(null);
+            s.setWords(aligned);
+            s.setStatus("ready");
+            s.setPartialText("");
+            s.setProgress({ message: "", value: null });
+          } catch (err) {
+            s.setSyncTokens(null);
+            s.setError(
+              err instanceof Error
+                ? err.message
+                : "Could not sync that transcript to the audio."
+            );
+          }
+          break;
+        }
+        s.setWords(msg.words);
+        s.setStatus("ready");
+        s.setPartialText("");
+        break;
+      }
+      case "error":
+        s.setSyncTokens(null);
+        s.setError(msg.message);
+        break;
+    }
+  };
+  worker.onerror = (err) => {
+    const s = useEditorStore.getState();
+    if (s.skipTranscription) return;
+    s.setSyncTokens(null);
+    s.setError(err.message || "Transcription worker crashed.");
+  };
+
+  const copy = audio.slice();
+  worker.postMessage(
+    { audio: copy, duration, model: whisperModel },
+    [copy.buffer]
+  );
+}
+
 /** Owns the transcription web worker and pipes its messages into the store. */
 export function useTranscriber() {
-  const workerRef = useRef<Worker | null>(null);
-
   useEffect(() => {
     return () => {
       cancelTranscription();
-      workerRef.current = null;
     };
   }, []);
 
+  // Keep a ref so Strict Mode remounts don't leave a dangling worker pointer
+  // in local state; the module-level activeWorker is the source of truth.
+  const workerRef = useRef<Worker | null>(null);
   const transcribe = useCallback((audio: Float32Array, duration: number) => {
-    const store = useEditorStore.getState();
-    if (!isWhisperModel(store.model)) {
-      store.setError("Select Whisper Base or Small to transcribe.");
-      return;
-    }
-    const whisperModel = store.model;
-    store.setStatus("transcribing");
-    store.setProgress({ message: "Loading speech model…", value: null });
-
-    // Always start a fresh worker so a prior cancel can't leave us without one.
-    cancelTranscription();
-    workerRef.current = new Worker(
-      new URL("../workers/transcription.worker.ts", import.meta.url),
-      { type: "module" }
-    );
-    activeWorker = workerRef.current;
-    workerRef.current.onmessage = (event: MessageEvent<WorkerResponse>) => {
-      const s = useEditorStore.getState();
-      // An imported transcript sets skipTranscription; ignore late Whisper results.
-      if (s.skipTranscription) return;
-      const msg = event.data;
-      switch (msg.type) {
-        case "progress":
-          s.setProgress({ message: msg.message, value: msg.value });
-          break;
-        case "partial":
-          s.setPartialText(msg.text);
-          break;
-        case "complete":
-          s.setWords(msg.words);
-          s.setStatus("ready");
-          s.setPartialText("");
-          break;
-        case "error":
-          s.setError(msg.message);
-          break;
-      }
-    };
-    workerRef.current.onerror = (err) => {
-      const s = useEditorStore.getState();
-      if (s.skipTranscription) return;
-      s.setError(err.message || "Transcription worker crashed.");
-    };
-
-    // Transfer a copy so the original stays available for the waveform.
-    const copy = audio.slice();
-    workerRef.current.postMessage(
-      { audio: copy, duration, model: whisperModel },
-      [copy.buffer]
-    );
+    startTranscription(audio, duration);
+    workerRef.current = activeWorker;
   }, []);
 
   return { transcribe, cancel: cancelTranscription };

--- a/lib/alignTranscript.ts
+++ b/lib/alignTranscript.ts
@@ -1,0 +1,181 @@
+import type { Word } from "./types";
+
+/** One token from a plain-text transcript waiting to be timed against audio. */
+export interface AlignToken {
+  text: string;
+  /** 0-based speaker index from `Name:` labels (0 when unlabeled). */
+  speaker: number;
+}
+
+const MATCH = 2;
+const MISMATCH = -1;
+const GAP = -1;
+
+/** Lowercase + strip punctuation so "Hello," matches Whisper's "hello". */
+export function normalizeToken(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\p{L}\p{N}']+/gu, "");
+}
+
+/**
+ * Align a reference (untimed) transcript to ASR words that already have
+ * timestamps — same idea as Descript's "Sync" for pasted text.
+ *
+ * Uses Needleman–Wunsch on normalized tokens, then copies / interpolates
+ * timings from the ASR anchors onto the reference words. Reference speaker
+ * labels win over diarization.
+ */
+export function alignTranscript(
+  reference: AlignToken[],
+  asr: Word[],
+  mediaDuration?: number
+): Word[] {
+  if (reference.length === 0) {
+    throw new Error("That transcript has no words to sync.");
+  }
+  if (asr.length === 0) {
+    throw new Error(
+      "Could not sync — no speech was detected in the audio. Try a clearer clip."
+    );
+  }
+
+  const refNorm = reference.map((t) => normalizeToken(t.text));
+  const asrNorm = asr.map((w) => normalizeToken(w.text));
+
+  // Drop empty normalized tokens from matching (keep indices into originals).
+  const refIdx: number[] = [];
+  const asrIdx: number[] = [];
+  for (let i = 0; i < refNorm.length; i++) if (refNorm[i]) refIdx.push(i);
+  for (let i = 0; i < asrNorm.length; i++) if (asrNorm[i]) asrIdx.push(i);
+
+  const n = refIdx.length;
+  const m = asrIdx.length;
+  if (n === 0) {
+    throw new Error("That transcript has no words to sync.");
+  }
+
+  // DP matrix: (n+1) x (m+1). Store as flat array.
+  const cols = m + 1;
+  const score = new Float64Array((n + 1) * (m + 1));
+  const ptr = new Uint8Array((n + 1) * (m + 1)); // 0=diag, 1=up (ref gap), 2=left (asr gap)
+
+  for (let i = 1; i <= n; i++) {
+    score[i * cols] = i * GAP;
+    ptr[i * cols] = 1;
+  }
+  for (let j = 1; j <= m; j++) {
+    score[j] = j * GAP;
+    ptr[j] = 2;
+  }
+
+  for (let i = 1; i <= n; i++) {
+    const a = refNorm[refIdx[i - 1]];
+    for (let j = 1; j <= m; j++) {
+      const b = asrNorm[asrIdx[j - 1]];
+      const diag =
+        score[(i - 1) * cols + (j - 1)] + (a === b ? MATCH : MISMATCH);
+      const up = score[(i - 1) * cols + j] + GAP;
+      const left = score[i * cols + (j - 1)] + GAP;
+      let best = diag;
+      let p = 0;
+      if (up > best) {
+        best = up;
+        p = 1;
+      }
+      if (left > best) {
+        best = left;
+        p = 2;
+      }
+      score[i * cols + j] = best;
+      ptr[i * cols + j] = p;
+    }
+  }
+
+  // Map each reference token → matched ASR word index (into `asr`), or -1.
+  const matchAsr = new Int32Array(reference.length).fill(-1);
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    const p = ptr[i * cols + j];
+    if (i > 0 && j > 0 && p === 0) {
+      matchAsr[refIdx[i - 1]] = asrIdx[j - 1];
+      i--;
+      j--;
+    } else if (i > 0 && (j === 0 || p === 1)) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  const duration =
+    mediaDuration && mediaDuration > 0
+      ? mediaDuration
+      : asr[asr.length - 1]?.end ?? 0;
+
+  // Build timed words: matched tokens take ASR times; gaps interpolate.
+  const starts = new Float64Array(reference.length);
+  const ends = new Float64Array(reference.length);
+
+  for (let r = 0; r < reference.length; r++) {
+    const a = matchAsr[r];
+    if (a >= 0) {
+      starts[r] = asr[a].start;
+      ends[r] = Math.max(asr[a].start + 0.02, asr[a].end);
+    }
+  }
+
+  // Fill unmatched runs between anchors (and leading/trailing edges).
+  let r = 0;
+  while (r < reference.length) {
+    if (matchAsr[r] >= 0) {
+      r++;
+      continue;
+    }
+    const runStart = r;
+    while (r < reference.length && matchAsr[r] < 0) r++;
+    const runEnd = r; // exclusive
+
+    const prev = runStart - 1;
+    const next = runEnd < reference.length ? runEnd : -1;
+    const t0 =
+      prev >= 0 ? ends[prev] : next >= 0 ? Math.max(0, starts[next] - 0.05) : 0;
+    const t1 =
+      next >= 0
+        ? starts[next]
+        : Math.max(t0 + 0.05 * (runEnd - runStart), duration);
+
+    const span = Math.max(0.02 * (runEnd - runStart), t1 - t0);
+    const tokens = reference.slice(runStart, runEnd);
+    const totalChars =
+      tokens.reduce((n, t) => n + Math.max(1, t.text.length), 0) || tokens.length;
+    let cursor = t0;
+    for (let k = 0; k < tokens.length; k++) {
+      const idx = runStart + k;
+      const dur = (span * Math.max(1, tokens[k].text.length)) / totalChars;
+      const end =
+        k === tokens.length - 1 ? t0 + span : Math.min(t0 + span, cursor + dur);
+      starts[idx] = cursor;
+      ends[idx] = Math.max(cursor + 0.02, end);
+      cursor = ends[idx];
+    }
+  }
+
+  // Ensure monotonic non-decreasing starts (guard float wobble).
+  for (let r = 1; r < reference.length; r++) {
+    if (starts[r] < starts[r - 1]) starts[r] = starts[r - 1];
+    if (ends[r] < starts[r] + 0.02) ends[r] = starts[r] + 0.02;
+  }
+
+  return reference.map((tok, idx) => ({
+    id: idx,
+    text: tok.text,
+    start: starts[idx],
+    end: ends[idx],
+    speaker: tok.speaker,
+    deleted: false,
+  }));
+}

--- a/lib/parseTranscript.ts
+++ b/lib/parseTranscript.ts
@@ -1,18 +1,25 @@
+import type { AlignToken } from "./alignTranscript";
 import type { Word } from "./types";
 
-/** Caption / transcript files we can turn into timed words. */
+/** Caption / transcript files we can turn into timed or syncable words. */
 export const TRANSCRIPT_ACCEPT =
-  ".srt,.vtt,.json,application/json,text/vtt,text/plain";
+  ".srt,.vtt,.json,.txt,application/json,text/vtt,text/plain";
 
-const TRANSCRIPT_EXT = /\.(srt|vtt|json)$/i;
+const TRANSCRIPT_EXT = /\.(srt|vtt|json|txt)$/i;
 
 export function isTranscriptFile(file: File): boolean {
   return (
     TRANSCRIPT_EXT.test(file.name) ||
     file.type === "application/json" ||
-    file.type === "text/vtt"
+    file.type === "text/vtt" ||
+    file.type === "text/plain"
   );
 }
+
+/** Timed captions, or plain text that must be synced to audio (Descript-style). */
+export type ParsedTranscript =
+  | { kind: "timed"; words: Word[] }
+  | { kind: "untimed"; tokens: AlignToken[] };
 
 interface Cue {
   start: number;
@@ -22,44 +29,85 @@ interface Cue {
 }
 
 /**
- * Parse an SRT, WebVTT, or JSON transcript into editor `Word`s.
- * Cue text is split on whitespace; each cue's time span is distributed
- * across its tokens by character length (same idea as word correction).
+ * Parse an SRT, WebVTT, JSON, or plain-text transcript.
+ * Timed formats become editor `Word`s; plain text becomes tokens for sync.
  */
-export function parseTranscript(text: string, filename = ""): Word[] {
+export function parseTranscript(text: string, filename = ""): ParsedTranscript {
   const trimmed = text.replace(/^\uFEFF/, "").trim();
   if (!trimmed) throw new Error("That transcript file is empty.");
 
   const lower = filename.toLowerCase();
-  let words: Word[];
+
+  // Explicit plain-text files always sync (even if they happen to look like SRT).
+  if (lower.endsWith(".txt")) {
+    return { kind: "untimed", tokens: tokensFromPlainText(trimmed) };
+  }
+
   if (lower.endsWith(".json") || looksLikeJson(trimmed)) {
-    words = wordsFromJson(trimmed);
-  } else if (lower.endsWith(".vtt") || /^WEBVTT/i.test(trimmed)) {
-    words = wordsFromCues(parseVtt(trimmed));
-  } else if (lower.endsWith(".srt") || looksLikeSrt(trimmed)) {
-    words = wordsFromCues(parseSrt(trimmed));
-  } else {
-    // Fallbacks when the extension is missing or wrong.
-    try {
-      words = wordsFromJson(trimmed);
-    } catch {
-      try {
-        words = wordsFromCues(parseVtt(trimmed));
-      } catch {
-        words = wordsFromCues(parseSrt(trimmed));
-      }
+    return { kind: "timed", words: wordsFromJson(trimmed) };
+  }
+  if (lower.endsWith(".vtt") || /^WEBVTT/i.test(trimmed)) {
+    return { kind: "timed", words: wordsFromCues(parseVtt(trimmed)) };
+  }
+  if (lower.endsWith(".srt") || looksLikeSrt(trimmed)) {
+    return { kind: "timed", words: wordsFromCues(parseSrt(trimmed)) };
+  }
+
+  // Extension missing / wrong: prefer timed formats, then plain text.
+  try {
+    return { kind: "timed", words: wordsFromJson(trimmed) };
+  } catch {
+    /* continue */
+  }
+  if (/^WEBVTT/i.test(trimmed)) {
+    return { kind: "timed", words: wordsFromCues(parseVtt(trimmed)) };
+  }
+  if (looksLikeSrt(trimmed)) {
+    return { kind: "timed", words: wordsFromCues(parseSrt(trimmed)) };
+  }
+
+  return { kind: "untimed", tokens: tokensFromPlainText(trimmed) };
+}
+
+export async function parseTranscriptFile(
+  file: File
+): Promise<ParsedTranscript> {
+  const text = await file.text();
+  return parseTranscript(text, file.name);
+}
+
+/**
+ * Split plain text into tokens. Speaker labels use Descript's convention:
+ * `Speaker Name: dialogue text` (label applies until the next labeled line).
+ */
+export function tokensFromPlainText(text: string): AlignToken[] {
+  const speakerIds = new Map<string, number>();
+  let nextSpeaker = 0;
+  let speaker = 0;
+  const tokens: AlignToken[] = [];
+
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  for (const rawLine of lines) {
+    let line = rawLine.trim();
+    if (!line) continue;
+
+    const labeled = line.match(/^([A-Za-z][\w\s'-]{0,40}):\s+(.+)$/);
+    if (labeled) {
+      const name = labeled[1].trim();
+      if (!speakerIds.has(name)) speakerIds.set(name, nextSpeaker++);
+      speaker = speakerIds.get(name)!;
+      line = labeled[2].trim();
+    }
+
+    for (const t of line.split(/\s+/).filter(Boolean)) {
+      tokens.push({ text: t, speaker });
     }
   }
 
-  if (words.length === 0) {
-    throw new Error("No timed words found in that transcript.");
+  if (tokens.length === 0) {
+    throw new Error("No words found in that transcript.");
   }
-  return words;
-}
-
-export async function parseTranscriptFile(file: File): Promise<Word[]> {
-  const text = await file.text();
-  return parseTranscript(text, file.name);
+  return tokens;
 }
 
 function looksLikeJson(text: string): boolean {
@@ -124,6 +172,9 @@ function wordsFromJson(text: string): Word[] {
     });
   }
 
+  if (words.length === 0) {
+    throw new Error("No timed words found in that transcript.");
+  }
   return words;
 }
 
@@ -131,10 +182,10 @@ function parseSrt(text: string): Cue[] {
   const blocks = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split(/\n\n+/);
   const cues: Cue[] = [];
   for (const block of blocks) {
-    const lines = block.split("\n").map((l) => l.trimEnd()).filter((l, i, arr) => {
-      // Keep blank lines out; allow content lines.
-      return l.length > 0 || i === arr.length - 1;
-    }).filter((l) => l.length > 0);
+    const lines = block
+      .split("\n")
+      .map((l) => l.trimEnd())
+      .filter((l) => l.length > 0);
     if (lines.length < 2) continue;
     let idx = 0;
     if (/^\d+$/.test(lines[0].trim())) idx = 1;
@@ -151,7 +202,6 @@ function parseSrt(text: string): Cue[] {
 
 function parseVtt(text: string): Cue[] {
   let body = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  // Drop header + optional metadata until the first blank line after WEBVTT.
   body = body.replace(/^WEBVTT[^\n]*\n(?:.*\n)*?(?=\n)/i, "");
   const blocks = body.split(/\n\n+/);
   const cues: Cue[] = [];
@@ -162,7 +212,6 @@ function parseVtt(text: string): Cue[] {
       .filter((l) => l.length > 0 && !l.startsWith("NOTE"));
     if (lines.length === 0) continue;
     let idx = 0;
-    // Optional cue identifier line before the arrow.
     if (!parseTimeRange(lines[0])) {
       if (lines.length < 2 || !parseTimeRange(lines[1])) continue;
       idx = 1;
@@ -186,7 +235,6 @@ function parseTimeRange(line: string): { start: number; end: number } | null {
   const parts = line.split(/\s*-->\s*/);
   if (parts.length < 2) return null;
   const start = parseTimestamp(parts[0].trim());
-  // End may have cue settings after it ("align:start position:0%").
   const endToken = parts[1].trim().split(/\s+/)[0];
   const end = parseTimestamp(endToken);
   if (start === null || end === null) return null;
@@ -206,7 +254,6 @@ function parseTimestamp(raw: string): number | null {
 
 function stripCueMeta(raw: string): { text: string; speaker?: string } {
   let text = raw
-    // VTT voice spans: <v Speaker>…</v> or <v Speaker>…
     .replace(/<\/?c[^>]*>/gi, "")
     .replace(/<\/?b>/gi, "")
     .replace(/<\/?i>/gi, "")
@@ -218,7 +265,6 @@ function stripCueMeta(raw: string): { text: string; speaker?: string } {
     speaker = voiceOpen[1].trim();
     text = voiceOpen[2].replace(/<\/v>\s*$/i, "");
   } else {
-    // Strip any remaining tags; capture leading "Name: " speaker labels.
     text = text.replace(/<[^>]+>/g, "");
     const labeled = text.match(/^([A-Za-z][\w\s'-]{0,40}):\s+([\s\S]+)$/);
     if (labeled) {
@@ -271,6 +317,10 @@ function wordsFromCues(cues: Cue[]): Word[] {
       });
       cursor = end;
     }
+  }
+
+  if (words.length === 0) {
+    throw new Error("No timed words found in that transcript.");
   }
   return words;
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import type { EditorStatus, ProgressInfo, Word } from "./types";
+import type { AlignToken } from "./alignTranscript";
 import {
   isModelChoice,
   isWhisperModel,
@@ -17,10 +18,10 @@ import {
   type ProjectMeta,
 } from "./projects";
 
-interface PendingTranscript {
-  name: string;
-  words: Word[];
-}
+/** Caption file chosen on the upload screen (timed) or plain text to sync. */
+export type PendingTranscript =
+  | { name: string; kind: "timed"; words: Word[] }
+  | { name: string; kind: "untimed"; tokens: AlignToken[] };
 
 interface EditorState {
   // Media
@@ -34,15 +35,20 @@ interface EditorState {
   /** Transcript source selected on the upload screen (Whisper or import). */
   model: ModelChoice;
   /**
-   * Caption file parsed on the upload screen when source is "import".
+   * Caption / text file parsed on the upload screen when source is "import".
    * Cleared when switching back to a Whisper model or after media loads.
    */
   pendingTranscript: PendingTranscript | null;
+  /**
+   * Untimed tokens waiting to be aligned after Whisper finishes (Descript-style
+   * sync). Set when loading media with a plain-text transcript.
+   */
+  syncTokens: AlignToken[] | null;
   /** IndexedDB project id when this session is persisted; null for a fresh upload mid-pipeline. */
   projectId: string | null;
   /**
    * When true, Editor extracts audio for the waveform but skips Whisper
-   * (restored projects / imported transcripts already have words).
+   * (restored projects / timed imported transcripts already have words).
    */
   skipTranscription: boolean;
 
@@ -69,14 +75,22 @@ interface EditorState {
   exportOpen: boolean;
 
   // Actions
-  /** Load media for editing. Pass `words` to skip Whisper and use that transcript. */
-  loadVideo: (file: File, options?: { words?: Word[] }) => void;
+  /**
+   * Load media for editing.
+   * - `words`: timed transcript → skip Whisper
+   * - `syncTokens`: plain text → run Whisper then align
+   */
+  loadVideo: (
+    file: File,
+    options?: { words?: Word[]; syncTokens?: AlignToken[] }
+  ) => void;
   /** Restore a saved project from IndexedDB (no re-transcription). */
   openProject: (id: string) => Promise<void>;
   /** Delete a saved project; if it is the active one, resets to the home screen. */
   removeProject: (id: string) => Promise<void>;
   setModel: (m: ModelChoice) => void;
   setPendingTranscript: (t: PendingTranscript | null) => void;
+  setSyncTokens: (t: AlignToken[] | null) => void;
   setDuration: (d: number) => void;
   setAudio: (a: Float32Array) => void;
   setStatus: (s: EditorStatus) => void;
@@ -86,7 +100,7 @@ interface EditorState {
   setWords: (words: Word[]) => void;
   /**
    * Replace the current transcript with an imported one (keeps media).
-   * Used when the user brings their own SRT/VTT/JSON instead of Whisper.
+   * Used for timed SRT/VTT/JSON, or after aligning plain text.
    */
   importWords: (words: Word[]) => void;
   deleteWords: (ids: number[]) => void;
@@ -117,6 +131,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   audio: null,
   model: "base",
   pendingTranscript: null,
+  syncTokens: null,
   projectId: null,
   skipTranscription: false,
 
@@ -141,21 +156,36 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     const kind = detectMediaKind(file);
     if (!kind) return;
     const imported = options?.words;
+    const syncTokens = options?.syncTokens ?? null;
     if (imported && imported.length === 0) return;
+    if (syncTokens && syncTokens.length === 0) return;
     const prev = get().mediaUrl;
     if (prev) URL.revokeObjectURL(prev);
     const current = get().model;
+    const timedImport = Boolean(imported);
+    const syncImport = Boolean(syncTokens);
     set({
       videoFile: file,
       mediaUrl: URL.createObjectURL(file),
       mediaKind: kind,
       projectId: null,
-      skipTranscription: Boolean(imported),
-      model: imported ? "import" : isWhisperModel(current) ? current : "base",
+      // Timed captions skip Whisper; plain text still needs ASR for timing.
+      skipTranscription: timedImport,
+      syncTokens: syncImport ? syncTokens : null,
+      model:
+        timedImport || syncImport
+          ? "import"
+          : isWhisperModel(current)
+            ? current
+            : "base",
       pendingTranscript: null,
       status: "preparing",
       progress: {
-        message: imported ? "Loading media…" : "Loading media engine…",
+        message: timedImport
+          ? "Loading media…"
+          : syncImport
+            ? "Loading media to sync transcript…"
+            : "Loading media engine…",
         value: null,
       },
       words: imported ? imported : [],
@@ -185,6 +215,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       projectId: record.id,
       skipTranscription: true,
       pendingTranscript: null,
+      syncTokens: null,
       status: "preparing",
       progress: { message: "Loading media engine…", value: null },
       words: record.words,
@@ -211,12 +242,13 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   setModel: (model) => {
     if (isWhisperModel(model)) {
       saveModelPreference(model);
-      set({ model, pendingTranscript: null });
+      set({ model, pendingTranscript: null, syncTokens: null });
     } else {
       set({ model });
     }
   },
   setPendingTranscript: (pendingTranscript) => set({ pendingTranscript }),
+  setSyncTokens: (syncTokens) => set({ syncTokens }),
   setDuration: (duration) => {
     set({ duration });
     if (get().status === "ready") bumpAutosave();
@@ -254,6 +286,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       status: "ready",
       progress: { message: "", value: null },
       skipTranscription: true,
+      syncTokens: null,
       model: "import",
     });
     bumpAutosave();
@@ -372,6 +405,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       audio: null,
       model: loadModelPreference(),
       pendingTranscript: null,
+      syncTokens: null,
       projectId: null,
       skipTranscription: false,
       status: "idle",

--- a/scripts/parse-transcript-test.ts
+++ b/scripts/parse-transcript-test.ts
@@ -1,15 +1,17 @@
 /**
- * Unit tests for SRT / VTT / JSON transcript import.
+ * Unit tests for SRT / VTT / JSON / plain-text transcript import + sync align.
  * Run: npx tsx scripts/parse-transcript-test.ts
  */
+import { alignTranscript } from "../lib/alignTranscript";
 import { parseTranscript } from "../lib/parseTranscript";
+import type { Word } from "../lib/types";
 
 function assert(cond: boolean, msg: string) {
   if (!cond) throw new Error(msg);
 }
 
 {
-  const words = parseTranscript(
+  const parsed = parseTranscript(
     `1
 00:00:01,000 --> 00:00:03,000
 Hello world
@@ -20,6 +22,9 @@ Alice: How are you?
 `,
     "sample.srt"
   );
+  assert(parsed.kind === "timed", "srt is timed");
+  if (parsed.kind !== "timed") throw new Error("unreachable");
+  const words = parsed.words;
   assert(words.length === 5, `srt expected 5 words, got ${words.length}`);
   assert(words[0].text === "Hello", "srt first word");
   assert(words[0].start === 1, `srt start ${words[0].start}`);
@@ -31,7 +36,7 @@ Alice: How are you?
 }
 
 {
-  const words = parseTranscript(
+  const parsed = parseTranscript(
     `WEBVTT
 
 00:00:00.000 --> 00:00:02.000
@@ -42,6 +47,9 @@ Alice: How are you?
 `,
     "sample.vtt"
   );
+  assert(parsed.kind === "timed", "vtt is timed");
+  if (parsed.kind !== "timed") throw new Error("unreachable");
+  const words = parsed.words;
   assert(words.length === 6, `vtt expected 6 words, got ${words.length}`);
   assert(words[0].speaker === 0 && words[0].text === "Winter", "vtt voice 0");
   assert(words[3].speaker === 1 && words[3].text === "You", "vtt voice 1");
@@ -49,7 +57,7 @@ Alice: How are you?
 }
 
 {
-  const words = parseTranscript(
+  const parsed = parseTranscript(
     JSON.stringify({
       words: [
         { text: "One", start: 0, end: 0.4, speaker: "A" },
@@ -58,9 +66,31 @@ Alice: How are you?
     }),
     "sample.json"
   );
-  assert(words.length === 2, "json length");
-  assert(words[0].speaker === 0 && words[1].speaker === 1, "json speakers");
+  assert(parsed.kind === "timed", "json is timed");
+  if (parsed.kind !== "timed") throw new Error("unreachable");
+  assert(parsed.words.length === 2, "json length");
+  assert(
+    parsed.words[0].speaker === 0 && parsed.words[1].speaker === 1,
+    "json speakers"
+  );
   console.log("json: ok");
+}
+
+{
+  const parsed = parseTranscript(
+    `Alice: Hello there, friend.
+Bob: Hi Alice — how are you?
+`,
+    "script.txt"
+  );
+  assert(parsed.kind === "untimed", "txt is untimed");
+  if (parsed.kind !== "untimed") throw new Error("unreachable");
+  assert(parsed.tokens.length === 9, `txt tokens ${parsed.tokens.length}`);
+  assert(parsed.tokens[0].text === "Hello", "txt strips speaker label");
+  assert(parsed.tokens[0].speaker === 0, "Alice → speaker 0");
+  assert(parsed.tokens[3].text === "Hi", "Bob line");
+  assert(parsed.tokens[3].speaker === 1, "Bob → speaker 1");
+  console.log("txt: ok");
 }
 
 {
@@ -72,6 +102,49 @@ Alice: How are you?
   }
   assert(threw, "empty should throw");
   console.log("empty: ok");
+}
+
+{
+  const asr: Word[] = [
+    { id: 0, text: "hello", start: 0.0, end: 0.4, speaker: 0, deleted: false },
+    { id: 1, text: "there", start: 0.4, end: 0.8, speaker: 0, deleted: false },
+    { id: 2, text: "friend", start: 0.9, end: 1.3, speaker: 0, deleted: false },
+  ];
+  const aligned = alignTranscript(
+    [
+      { text: "Hello,", speaker: 0 },
+      { text: "there", speaker: 0 },
+      { text: "friend!", speaker: 1 },
+    ],
+    asr,
+    2
+  );
+  assert(aligned.length === 3, "align length");
+  assert(aligned[0].text === "Hello,", "keeps reference spelling");
+  assert(aligned[0].start === 0, "matched start");
+  assert(aligned[2].speaker === 1, "reference speaker wins");
+  assert(aligned[2].end > aligned[2].start, "positive duration");
+  console.log("align: ok");
+}
+
+{
+  // Extra reference word gets interpolated between anchors.
+  const asr: Word[] = [
+    { id: 0, text: "one", start: 0, end: 0.3, speaker: 0, deleted: false },
+    { id: 1, text: "three", start: 1.0, end: 1.4, speaker: 0, deleted: false },
+  ];
+  const aligned = alignTranscript(
+    [
+      { text: "one", speaker: 0 },
+      { text: "two", speaker: 0 },
+      { text: "three", speaker: 0 },
+    ],
+    asr
+  );
+  assert(aligned[1].text === "two", "interpolated token");
+  assert(aligned[1].start >= aligned[0].end - 1e-6, "monotonic");
+  assert(aligned[1].end <= aligned[2].start + 1e-6, "before next");
+  console.log("align interpolate: ok");
 }
 
 console.log("ALL PARSE TRANSCRIPT TESTS PASSED");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds Descript-style **sync for plain-text transcripts** (no timestamps), including **paste**. Timed SRT/VTT/JSON import is unchanged.

## How it works
Same idea as [Descript’s “Use your own transcript”](https://help.descript.com/hc/en-us/articles/10249406128781-Use-your-own-transcript):

1. **Import transcript** → paste text (or choose a file)
2. Optional speaker labels: `Speaker Name: dialogue`
3. Drop media (or Replace mid-session)
4. Whisper runs for **timing only** (plain text); timed captions skip Whisper
5. Your words are **aligned** onto those timestamps (Needleman–Wunsch; gaps interpolate)
6. Reference spelling + speaker labels are kept

## UI
- Upload source menu → Import opens a paste dialog (“Use transcript” + “Choose file…”)
- Editor transcript panel → Import opens the same dialog (“Sync transcript” when replacing)

## Test plan
- [ ] Import → paste `Alice: …` / `Bob: …` → trigger shows pasted transcript / syncs to audio
- [ ] Drop media → progress says syncing → transcript uses pasted text with sensible timings
- [ ] Paste or choose an SRT/VTT/JSON → still skips Whisper and loads immediately
- [ ] Mid-session Import → paste → Sync replaces/aligns against the current transcript
- [ ] Choose file… from the dialog still works
- [ ] `npx tsx scripts/parse-transcript-test.ts` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0a6-b882-7c0b-a708-14fddf9ae2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

