### PR TITLE
Descript-style word timing, Split, and clip trim on the timeline

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -96,14 +96,14 @@ Everything else is derived:
 5. ✅ Editing core: word selection → cut/restore, undo/redo, playback that
    skips cuts, show/hide deleted words.
 6. ✅ Export: keep-range concat render to MP4 with progress, download.
+7. ✅ Flexible timeline editing: word-boundary drag, Split at playhead
+   (scene boundaries), clip trim handles, manual cuts merged into export.
 
 ## Future work
 
-- Correct/retype words (text overrides for captions), speaker renaming.
-- Filler-word detection ("um", "uh") with one-click removal.
 - Larger Whisper variants + language selection UI; local model import for
   air-gapped first runs.
 - Smarter export: stream-copy for keyframe-aligned segments, WebCodecs-based
   rendering for speed.
-- Multi-clip projects, captions burn-in, audio-only export.
-- Persist projects to IndexedDB / OPFS so refreshes keep edits.
+- Multi-clip projects (reorder scenes), captions burn-in.
+- Gap clips / insert silence between words.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ the media. Export the final cut — without your file ever leaving your device.
 - 📥 **Import your own transcript** — skip Whisper and edit with an SRT, VTT, or JSON caption file
 - 🧹 **Filler removal** — one-click cut of "um", "uh", and similar fillers
 - 🗣️ **Speaker diarization** — the transcript is grouped by speaker
-- 🎬 **Timeline** — waveform, word labels, cut regions, playhead, zoom
+- 🎬 **Timeline** — waveform, wordbar with draggable timing handles, Split,
+  cut regions, playhead, zoom
+- ✂️ **Split & trim** — blade clips at the playhead; drag clip edges to refine
+  cuts beyond word boundaries
+- 🎯 **Word timing** — zoom in and drag a word's edges when ASR alignment is off
 - ⚡ **Live preview** — playback skips your cuts in real time
 - 📦 **In-browser export** — frame-accurate MP4 (video) or M4A (audio) with ffmpeg.wasm
 - 🎧 **Audio files** — edit podcasts, voice notes, and interviews the same way as video

--- a/app/globals.css
+++ b/app/globals.css
@@ -42,3 +42,39 @@ body {
 .scrollbar-thin::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* Timeline: split confirmation flash */
+@keyframes tl-split-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.55);
+  }
+  100% {
+    box-shadow: 0 0 0 10px rgba(251, 191, 36, 0);
+  }
+}
+.tl-split-flash {
+  animation: tl-split-flash 0.42s ease-out;
+}
+
+@keyframes tl-playhead-pulse {
+  0%,
+  100% {
+    transform: translateX(-50%) scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: translateX(-50%) scale(1.35);
+    opacity: 0.75;
+  }
+}
+.tl-playhead-split {
+  animation: tl-playhead-pulse 1.6s ease-in-out infinite;
+}
+
+.tl-trim-handle:hover > div {
+  transform: scaleX(1.4);
+}
+.tl-word-handle:hover > span {
+  opacity: 1 !important;
+  width: 2px;
+}

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -46,7 +46,7 @@ export default function Editor() {
     })();
   }, [videoFile, skipTranscription, transcribe]);
 
-  // Global shortcuts: space = play/pause, ⌘Z / ⇧⌘Z = undo / redo.
+  // Global shortcuts: space = play/pause, ⌘Z / ⇧⌘Z = undo / redo, S = split.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
@@ -61,6 +61,16 @@ export default function Editor() {
         e.preventDefault();
         if (e.shiftKey) s.redo();
         else s.undo();
+      } else if (
+        e.key.toLowerCase() === "s" &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        s.status === "ready" &&
+        !s.exportOpen
+      ) {
+        e.preventDefault();
+        s.splitAtPlayhead();
       }
     };
     document.addEventListener("keydown", handler);

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -12,6 +12,7 @@ export default function ExportDialog() {
   const videoFile = useEditorStore((s) => s.videoFile);
   const mediaKind = useEditorStore((s) => s.mediaKind);
   const words = useEditorStore((s) => s.words);
+  const manualCuts = useEditorStore((s) => s.manualCuts);
   const duration = useEditorStore((s) => s.duration);
   const status = useEditorStore((s) => s.status);
   const setStatus = useEditorStore((s) => s.setStatus);
@@ -21,7 +22,10 @@ export default function ExportDialog() {
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
+  const cuts = useMemo(
+    () => getCutRanges(words, duration, manualCuts),
+    [words, duration, manualCuts]
+  );
   const editedDuration = useMemo(() => getEditedDuration(cuts, duration), [cuts, duration]);
   const exporting = status === "exporting";
   const isAudio = mediaKind === "audio";

--- a/components/MediaPreview.tsx
+++ b/components/MediaPreview.tsx
@@ -16,6 +16,7 @@ export default function MediaPreview() {
   const videoFile = useEditorStore((s) => s.videoFile);
   const mediaKind = useEditorStore((s) => s.mediaKind);
   const words = useEditorStore((s) => s.words);
+  const manualCuts = useEditorStore((s) => s.manualCuts);
   const duration = useEditorStore((s) => s.duration);
   const playing = useEditorStore((s) => s.playing);
   const currentTime = useEditorStore((s) => s.currentTime);
@@ -26,7 +27,10 @@ export default function MediaPreview() {
 
   const mediaRef = useRef<HTMLMediaElement | null>(null);
   const isAudio = mediaKind === "audio";
-  const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
+  const cuts = useMemo(
+    () => getCutRanges(words, duration, manualCuts),
+    [words, duration, manualCuts]
+  );
   const cutsRef = useRef(cuts);
   useEffect(() => {
     cutsRef.current = cuts;

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,36 +1,81 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Maximize2, ZoomIn, ZoomOut } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { Maximize2, Scissors, ZoomIn, ZoomOut } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
-import { formatTime, getCutRanges } from "@/lib/edits";
+import {
+  canSplitAt,
+  formatTime,
+  getClipSegments,
+  getCutRanges,
+  getKeepRanges,
+} from "@/lib/edits";
+import type { Word } from "@/lib/types";
 
-const RULER_H = 20;
-const LABELS_H = 20;
+const RULER_H = 18;
+const WORDBAR_H = 28;
 const SAMPLE_RATE = 16000;
 const TICK_STEPS = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
+/** Pixels-per-second below which word chips hide (too dense). */
+const WORD_VIS_PPS = 22;
+/** Pixels-per-second above which edge handles appear on words. */
+const HANDLE_VIS_PPS = 40;
+
+type DragKind =
+  | { type: "seek" }
+  | { type: "word"; wordId: number; edge: "start" | "end"; origStart: number; origEnd: number }
+  | { type: "trim"; clipIndex: number; edge: "in" | "out" };
 
 export default function Timeline() {
   const audio = useEditorStore((s) => s.audio);
   const words = useEditorStore((s) => s.words);
+  const manualCuts = useEditorStore((s) => s.manualCuts);
+  const sceneBoundaries = useEditorStore((s) => s.sceneBoundaries);
   const duration = useEditorStore((s) => s.duration);
   const currentTime = useEditorStore((s) => s.currentTime);
   const playing = useEditorStore((s) => s.playing);
+  const selectedClipIndex = useEditorStore((s) => s.selectedClipIndex);
+  const status = useEditorStore((s) => s.status);
 
-  const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
+  const cuts = useMemo(
+    () => getCutRanges(words, duration, manualCuts),
+    [words, duration, manualCuts]
+  );
+  const keeps = useMemo(() => getKeepRanges(cuts, duration), [cuts, duration]);
+  const clips = useMemo(
+    () => getClipSegments(keeps, sceneBoundaries),
+    [keeps, sceneBoundaries]
+  );
+  const splitOk = useMemo(
+    () => canSplitAt(currentTime, duration, cuts, sceneBoundaries),
+    [currentTime, duration, cuts, sceneBoundaries]
+  );
 
   const outerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dragRef = useRef<DragKind | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [splitFlash, setSplitFlash] = useState(false);
 
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
-  const [zoom, setZoom] = useState(1); // multiplier over "fit"
+  const [zoom, setZoom] = useState(1);
+  const [hoveredWordId, setHoveredWordId] = useState<number | null>(null);
+  const [hoveredClipIndex, setHoveredClipIndex] = useState<number | null>(null);
 
   const fitPps = duration > 0 && width > 0 ? width / duration : 50;
   const pps = fitPps * zoom;
   const totalWidth = Math.max(width, duration * pps);
+  const ready = status === "ready" && duration > 0;
 
   useEffect(() => {
     const el = outerRef.current;
@@ -43,7 +88,7 @@ export default function Timeline() {
     return () => ro.disconnect();
   }, []);
 
-  // Draw ruler + waveform + cut overlay for the visible window.
+  // Draw ruler + waveform + cut overlay + clip tint for the visible window.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || width === 0 || height === 0) return;
@@ -55,9 +100,13 @@ export default function Timeline() {
     ctx.scale(dpr, dpr);
     ctx.clearRect(0, 0, width, height);
 
-    const trackTop = RULER_H + LABELS_H;
+    const trackTop = RULER_H + WORDBAR_H;
     const trackH = height - trackTop;
     const midY = trackTop + trackH / 2;
+
+    // Soft track wash
+    ctx.fillStyle = "#fafafa";
+    ctx.fillRect(0, trackTop, width, trackH);
 
     // Ruler
     ctx.fillStyle = "#a1a1aa";
@@ -78,18 +127,57 @@ export default function Timeline() {
     ctx.lineTo(width, RULER_H - 0.5);
     ctx.stroke();
 
+    // Wordbar lane background
+    ctx.fillStyle = "#f4f4f5";
+    ctx.fillRect(0, RULER_H, width, WORDBAR_H);
+    ctx.strokeStyle = "#ececef";
+    ctx.beginPath();
+    ctx.moveTo(0, RULER_H + WORDBAR_H - 0.5);
+    ctx.lineTo(width, RULER_H + WORDBAR_H - 0.5);
+    ctx.stroke();
+
     if (!audio || duration === 0) return;
+
+    // Clip selection / hover washes on waveform
+    for (const clip of clips) {
+      const x0 = clip.start * pps - scrollLeft;
+      const x1 = clip.end * pps - scrollLeft;
+      if (x1 < 0 || x0 > width) continue;
+      const selected = clip.index === selectedClipIndex;
+      const hovered = clip.index === hoveredClipIndex && !selected;
+      if (selected) {
+        ctx.fillStyle = "rgba(99, 102, 241, 0.10)";
+        ctx.fillRect(x0, trackTop, x1 - x0, trackH);
+      } else if (hovered) {
+        ctx.fillStyle = "rgba(99, 102, 241, 0.05)";
+        ctx.fillRect(x0, trackTop, x1 - x0, trackH);
+      }
+    }
 
     // Cut range backgrounds
     for (const cut of cuts) {
       const x0 = cut.start * pps - scrollLeft;
       const x1 = cut.end * pps - scrollLeft;
       if (x1 < 0 || x0 > width) continue;
-      ctx.fillStyle = "rgba(254, 226, 226, 0.85)";
+      ctx.fillStyle = "rgba(254, 226, 226, 0.78)";
       ctx.fillRect(x0, trackTop, x1 - x0, trackH);
+      // subtle hatch
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(x0, trackTop, x1 - x0, trackH);
+      ctx.clip();
+      ctx.strokeStyle = "rgba(252, 165, 165, 0.45)";
+      ctx.lineWidth = 1;
+      for (let x = x0 - trackH; x < x1 + trackH; x += 6) {
+        ctx.beginPath();
+        ctx.moveTo(x, trackTop);
+        ctx.lineTo(x + trackH, trackTop + trackH);
+        ctx.stroke();
+      }
+      ctx.restore();
     }
 
-    // Waveform: per-column min/max, sampled with a stride to bound work.
+    // Waveform
     const samplesPerPx = SAMPLE_RATE / pps;
     const stride = Math.max(1, Math.floor(samplesPerPx / 40));
     for (let x = 0; x < width; x++) {
@@ -109,7 +197,18 @@ export default function Timeline() {
       const h = Math.max(1, (max - min) * trackH * 0.45);
       ctx.fillRect(x, midY - h / 2, 1, h);
     }
-  }, [audio, cuts, duration, pps, scrollLeft, width, height]);
+  }, [
+    audio,
+    cuts,
+    clips,
+    duration,
+    pps,
+    scrollLeft,
+    width,
+    height,
+    selectedClipIndex,
+    hoveredClipIndex,
+  ]);
 
   // Keep the playhead visible while playing.
   useEffect(() => {
@@ -122,56 +221,191 @@ export default function Timeline() {
     }
   }, [currentTime, playing, pps, width]);
 
-  const seekFromPointer = useCallback(
+  const timeFromClientX = useCallback(
     (clientX: number) => {
       const el = scrollRef.current;
-      if (!el) return;
+      if (!el) return 0;
       const rect = el.getBoundingClientRect();
-      const t = Math.min(
+      return Math.min(
         Math.max(0, (clientX - rect.left + el.scrollLeft) / pps),
         duration
       );
-      const { videoEl, setCurrentTime } = useEditorStore.getState();
-      if (videoEl) videoEl.currentTime = t;
-      setCurrentTime(t);
     },
     [pps, duration]
   );
 
-  const onPointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      e.currentTarget.setPointerCapture(e.pointerId);
-      seekFromPointer(e.clientX);
-    },
-    [seekFromPointer]
-  );
+  const seekTo = useCallback((t: number) => {
+    const { videoEl, setCurrentTime } = useEditorStore.getState();
+    if (videoEl) videoEl.currentTime = t;
+    setCurrentTime(t);
+  }, []);
+
+  const endDrag = useCallback(() => {
+    if (dragRef.current) {
+      useEditorStore.getState().endGesture();
+      dragRef.current = null;
+      setDragging(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const onUp = () => endDrag();
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+    return () => {
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+  }, [endDrag]);
 
   const onPointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (e.buttons & 1) seekFromPointer(e.clientX);
+    (e: ReactPointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) {
+        // Hover clip under cursor (waveform area)
+        const t = timeFromClientX(e.clientX);
+        const clip = clips.find((c) => t >= c.start && t < c.end);
+        setHoveredClipIndex(clip?.index ?? null);
+        return;
+      }
+      const t = timeFromClientX(e.clientX);
+      const store = useEditorStore.getState();
+
+      if (drag.type === "seek") {
+        seekTo(t);
+        return;
+      }
+      if (drag.type === "word") {
+        if (drag.edge === "start") {
+          store.adjustWordBounds(drag.wordId, t, drag.origEnd);
+        } else {
+          store.adjustWordBounds(drag.wordId, drag.origStart, t);
+        }
+        return;
+      }
+      if (drag.type === "trim") {
+        store.trimClipEdge(drag.clipIndex, drag.edge, t);
+      }
     },
-    [seekFromPointer]
+    [clips, seekTo, timeFromClientX]
   );
 
-  // Word labels for the visible window (only when zoomed in enough to read).
+  const onBackgroundPointerDown = useCallback(
+    (e: ReactPointerEvent) => {
+      if (e.button !== 0) return;
+      // Ignore if clicking interactive chrome (handles / chips set their own drag)
+      const target = e.target as HTMLElement;
+      if (target.closest("[data-tl-interactive]")) return;
+
+      const t = timeFromClientX(e.clientX);
+      const clip = clips.find((c) => t >= c.start && t < c.end);
+      useEditorStore.getState().setSelectedClipIndex(clip?.index ?? null);
+      dragRef.current = { type: "seek" };
+      setDragging(true);
+      e.currentTarget.setPointerCapture(e.pointerId);
+      seekTo(t);
+    },
+    [clips, seekTo, timeFromClientX]
+  );
+
+  const startWordDrag = useCallback(
+    (e: ReactPointerEvent, word: Word, edge: "start" | "end") => {
+      e.stopPropagation();
+      e.preventDefault();
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      useEditorStore.getState().beginGesture();
+      dragRef.current = {
+        type: "word",
+        wordId: word.id,
+        edge,
+        origStart: word.start,
+        origEnd: word.end,
+      };
+      setDragging(true);
+    },
+    []
+  );
+
+  const startTrimDrag = useCallback(
+    (e: ReactPointerEvent, clipIndex: number, edge: "in" | "out") => {
+      e.stopPropagation();
+      e.preventDefault();
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      const store = useEditorStore.getState();
+      store.setSelectedClipIndex(clipIndex);
+      store.beginGesture();
+      dragRef.current = { type: "trim", clipIndex, edge };
+      setDragging(true);
+    },
+    []
+  );
+
+  const doSplit = useCallback(() => {
+    const ok = useEditorStore.getState().splitAtPlayhead();
+    if (!ok) return;
+    setSplitFlash(true);
+    window.setTimeout(() => setSplitFlash(false), 420);
+  }, []);
+
+  // Word labels for the visible window
   const visibleWords = useMemo(() => {
-    if (pps < 18) return [];
+    if (pps < WORD_VIS_PPS) return [];
     const t0 = scrollLeft / pps - 1;
     const t1 = (scrollLeft + width) / pps + 1;
     return words.filter((w) => w.end >= t0 && w.start <= t1);
   }, [words, pps, scrollLeft, width]);
 
   const playheadX = currentTime * pps - scrollLeft;
+  const showHandles = pps >= HANDLE_VIS_PPS;
 
   return (
-    <footer className="flex h-44 shrink-0 flex-col border-t border-zinc-200 bg-white">
+    <footer className="flex h-52 shrink-0 flex-col border-t border-zinc-200 bg-white">
       <div className="flex h-9 shrink-0 items-center gap-2 border-b border-zinc-100 px-3">
         <span className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
           Timeline
         </span>
-        <span className="text-xs tabular-nums text-zinc-400">{formatTime(currentTime)}</span>
-        <div className="ml-auto flex items-center gap-0.5">
+        <span className="text-xs tabular-nums text-zinc-400">
+          {formatTime(currentTime)}
+        </span>
+
+        <div className="mx-auto flex items-center">
           <button
+            type="button"
+            disabled={!ready || !splitOk}
+            onClick={doSplit}
+            title={
+              splitOk
+                ? "Split clip at playhead (S)"
+                : "Move the playhead onto a kept region to split"
+            }
+            className={`group relative flex h-8 items-center gap-1.5 rounded-full px-3 text-xs font-medium transition-all duration-200 ${
+              ready && splitOk
+                ? "bg-zinc-900 text-white shadow-sm shadow-zinc-900/10 hover:bg-zinc-800 active:scale-[0.97]"
+                : "cursor-not-allowed bg-zinc-100 text-zinc-400"
+            } ${splitFlash ? "tl-split-flash" : ""}`}
+          >
+            <Scissors
+              size={13}
+              className={`transition-transform duration-300 ${
+                splitFlash ? "rotate-[-18deg] scale-110" : "group-hover:rotate-[-8deg]"
+              }`}
+            />
+            Split
+            <kbd
+              className={`ml-0.5 rounded px-1 py-px text-[10px] font-normal ${
+                ready && splitOk
+                  ? "bg-white/15 text-zinc-200"
+                  : "bg-zinc-200/80 text-zinc-400"
+              }`}
+            >
+              S
+            </kbd>
+          </button>
+        </div>
+
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
             onClick={() => setZoom((z) => Math.max(1, z / 1.5))}
             title="Zoom out"
             className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-zinc-100"
@@ -179,6 +413,7 @@ export default function Timeline() {
             <ZoomOut size={14} />
           </button>
           <button
+            type="button"
             onClick={() => setZoom(1)}
             title="Fit"
             className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-zinc-100"
@@ -186,8 +421,9 @@ export default function Timeline() {
             <Maximize2 size={13} />
           </button>
           <button
+            type="button"
             onClick={() => setZoom((z) => Math.min(256, z * 1.5))}
-            title="Zoom in"
+            title="Zoom in — drag word edges to refine timing"
             className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-zinc-100"
           >
             <ZoomIn size={14} />
@@ -196,44 +432,204 @@ export default function Timeline() {
       </div>
 
       <div ref={outerRef} className="relative min-h-0 flex-1">
-        <canvas ref={canvasRef} className="pointer-events-none absolute inset-0 h-full w-full" />
+        <canvas
+          ref={canvasRef}
+          className="pointer-events-none absolute inset-0 h-full w-full"
+        />
 
         <div
           ref={scrollRef}
           onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
-          onPointerDown={onPointerDown}
+          onPointerDown={onBackgroundPointerDown}
           onPointerMove={onPointerMove}
-          className="scrollbar-thin absolute inset-0 cursor-col-resize touch-none overflow-x-auto overflow-y-hidden select-none"
+          className="scrollbar-thin absolute inset-0 touch-none overflow-x-auto overflow-y-hidden select-none"
+          style={{ cursor: dragging ? "col-resize" : "default" }}
         >
           <div className="relative h-full" style={{ width: totalWidth }}>
-            {visibleWords.map((w) => (
-              <span
-                key={w.id}
-                title={w.text}
-                className={`absolute block overflow-hidden rounded-sm border px-1 text-[10px] leading-[14px] text-ellipsis whitespace-nowrap ${
-                  w.deleted
-                    ? "border-red-200 bg-red-50 text-red-400 line-through"
-                    : "border-zinc-200 bg-white text-zinc-600"
-                }`}
-                style={{
-                  left: w.start * pps,
-                  top: RULER_H + 2,
-                  width: Math.max(5, (w.end - w.start) * pps - 1),
-                  height: 16,
-                }}
-              >
-                {w.text}
-              </span>
-            ))}
+            {/* Scene boundary markers */}
+            {sceneBoundaries.map((b) => {
+              const x = b.time * pps;
+              return (
+                <div
+                  key={b.id}
+                  data-tl-interactive
+                  className="tl-boundary group/boundary absolute top-0 bottom-0 z-[5] w-3 -translate-x-1/2 cursor-pointer"
+                  style={{ left: x }}
+                  title="Scene split — double-click to join"
+                  onDoubleClick={(e) => {
+                    e.stopPropagation();
+                    useEditorStore.getState().removeSceneBoundary(b.id);
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-amber-400/80 transition group-hover/boundary:bg-amber-500" />
+                  <div className="absolute top-[3px] left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 rounded-[1px] bg-amber-400 shadow-sm shadow-amber-500/30 transition group-hover/boundary:scale-125 group-hover/boundary:bg-amber-500" />
+                </div>
+              );
+            })}
+
+            {/* Clip trim handles (selected or hovered) */}
+            {clips.map((clip) => {
+              const active =
+                clip.index === selectedClipIndex || clip.index === hoveredClipIndex;
+              if (!active) return null;
+              const selected = clip.index === selectedClipIndex;
+              return (
+                <div key={`trim-${clip.id}`}>
+                  <div
+                    data-tl-interactive
+                    onPointerDown={(e) => startTrimDrag(e, clip.index, "in")}
+                    className="tl-trim-handle absolute z-[6] -translate-x-1/2 cursor-ew-resize"
+                    style={{
+                      left: clip.start * pps,
+                      top: RULER_H + WORDBAR_H + 4,
+                      bottom: 4,
+                      opacity: selected ? 1 : 0.7,
+                    }}
+                    title="Trim clip start"
+                  >
+                    <div
+                      className={`h-full w-1 rounded-full transition-all duration-150 ${
+                        selected
+                          ? "bg-indigo-500 shadow-[0_0_0_3px_rgba(99,102,241,0.2)]"
+                          : "bg-indigo-400/80"
+                      }`}
+                    />
+                  </div>
+                  <div
+                    data-tl-interactive
+                    onPointerDown={(e) => startTrimDrag(e, clip.index, "out")}
+                    className="tl-trim-handle absolute z-[6] -translate-x-1/2 cursor-ew-resize"
+                    style={{
+                      left: clip.end * pps,
+                      top: RULER_H + WORDBAR_H + 4,
+                      bottom: 4,
+                      opacity: selected ? 1 : 0.7,
+                    }}
+                    title="Trim clip end"
+                  >
+                    <div
+                      className={`h-full w-1 rounded-full transition-all duration-150 ${
+                        selected
+                          ? "bg-indigo-500 shadow-[0_0_0_3px_rgba(99,102,241,0.2)]"
+                          : "bg-indigo-400/80"
+                      }`}
+                    />
+                  </div>
+                  {selected && (
+                    <div
+                      className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-indigo-400/40"
+                      style={{
+                        left: clip.start * pps,
+                        width: Math.max(2, (clip.end - clip.start) * pps),
+                        top: RULER_H + WORDBAR_H + 2,
+                        bottom: 2,
+                      }}
+                    />
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Wordbar chips */}
+            {visibleWords.map((w) => {
+              const wWidth = Math.max(6, (w.end - w.start) * pps - 1);
+              const hovered = hoveredWordId === w.id;
+              const showWordHandles = showHandles && (hovered || wWidth > 28);
+              return (
+                <div
+                  key={w.id}
+                  data-tl-interactive
+                  className={`tl-word absolute z-[3] flex items-center overflow-hidden rounded-md border text-[10px] leading-none transition-[box-shadow,background-color,border-color] duration-150 ${
+                    w.deleted
+                      ? "border-red-200/90 bg-red-50/95 text-red-400 line-through"
+                      : hovered
+                        ? "border-indigo-300 bg-white text-zinc-700 shadow-sm shadow-indigo-500/10"
+                        : "border-zinc-200/90 bg-white/95 text-zinc-600"
+                  }`}
+                  style={{
+                    left: w.start * pps,
+                    top: RULER_H + 5,
+                    width: wWidth,
+                    height: WORDBAR_H - 10,
+                  }}
+                  title={
+                    showHandles
+                      ? `${w.text} — drag edges to adjust timing`
+                      : w.text
+                  }
+                  onPointerEnter={() => setHoveredWordId(w.id)}
+                  onPointerLeave={() =>
+                    setHoveredWordId((id) => (id === w.id ? null : id))
+                  }
+                  onPointerDown={(e) => {
+                    // Clicking the chip body seeks to word start (not a bound drag)
+                    if ((e.target as HTMLElement).dataset.edge) return;
+                    e.stopPropagation();
+                    seekTo(w.start);
+                    // Select clip under this word
+                    const clip = clips.find(
+                      (c) => w.start >= c.start && w.start < c.end
+                    );
+                    useEditorStore
+                      .getState()
+                      .setSelectedClipIndex(clip?.index ?? null);
+                  }}
+                >
+                  <span className="pointer-events-none min-w-0 flex-1 truncate px-1.5">
+                    {w.text}
+                  </span>
+                  {showWordHandles && (
+                    <>
+                      <span
+                        data-edge="start"
+                        data-tl-interactive
+                        onPointerDown={(e) => startWordDrag(e, w, "start")}
+                        className="tl-word-handle absolute inset-y-0 left-0 z-10 w-1.5 cursor-ew-resize"
+                      >
+                        <span
+                          className={`absolute inset-y-1 left-0 w-0.5 rounded-full transition-all duration-150 ${
+                            hovered
+                              ? "bg-indigo-500 opacity-100"
+                              : "bg-zinc-300 opacity-0 group-hover:opacity-100"
+                          }`}
+                          style={{ opacity: hovered ? 1 : 0.55 }}
+                        />
+                      </span>
+                      <span
+                        data-edge="end"
+                        data-tl-interactive
+                        onPointerDown={(e) => startWordDrag(e, w, "end")}
+                        className="tl-word-handle absolute inset-y-0 right-0 z-10 w-1.5 cursor-ew-resize"
+                      >
+                        <span
+                          className="absolute inset-y-1 right-0 w-0.5 rounded-full bg-indigo-500 transition-opacity duration-150"
+                          style={{ opacity: hovered ? 1 : 0.55 }}
+                        />
+                      </span>
+                    </>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
 
-        {playheadX >= 0 && playheadX <= width && (
+        {playheadX >= -2 && playheadX <= width + 2 && (
           <div
-            className="pointer-events-none absolute top-0 bottom-0 z-10 w-px bg-zinc-900"
+            className="pointer-events-none absolute top-0 bottom-0 z-20 w-px bg-zinc-900/90"
             style={{ transform: `translateX(${playheadX}px)` }}
           >
-            <div className="absolute -top-px left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-sm bg-zinc-900 [clip-path:polygon(0_0,100%_0,100%_55%,50%_100%,0_55%)]" />
+            <div className="absolute -top-px left-1/2 h-2.5 w-2.5 -translate-x-1/2 rounded-sm bg-zinc-900 shadow-sm shadow-zinc-900/30 [clip-path:polygon(0_0,100%_0,100%_55%,50%_100%,0_55%)]" />
+            {splitOk && (
+              <div className="tl-playhead-split absolute top-[22px] left-1/2 h-1.5 w-1.5 -translate-x-1/2 rounded-full bg-amber-400 shadow-[0_0_0_3px_rgba(251,191,36,0.25)]" />
+            )}
+          </div>
+        )}
+
+        {pps < WORD_VIS_PPS && ready && (
+          <div className="pointer-events-none absolute bottom-2 left-1/2 z-10 -translate-x-1/2 rounded-full bg-zinc-900/70 px-2.5 py-1 text-[10px] text-white/90 backdrop-blur-sm transition-opacity">
+            Zoom in to edit word timing
           </div>
         )}
       </div>

--- a/lib/autosave.ts
+++ b/lib/autosave.ts
@@ -64,6 +64,8 @@ async function writeSnapshot() {
       model: s.model,
       words: s.words,
       showDeleted: s.showDeleted,
+      manualCuts: s.manualCuts,
+      sceneBoundaries: s.sceneBoundaries,
       media: s.videoFile,
       mediaType: s.videoFile.type,
       createdAt,

--- a/lib/edits.ts
+++ b/lib/edits.ts
@@ -1,14 +1,25 @@
-import type { TimeRange, Word } from "./types";
+import type {
+  ClipSegment,
+  ManualCut,
+  SceneBoundary,
+  TimeRange,
+  Word,
+} from "./types";
 
 /** Padding (s) applied when merging adjacent deleted words into one cut. */
 const MERGE_GAP = 0.35;
 
+/** Minimum kept clip length after a trim (seconds). */
+export const MIN_CLIP_DURATION = 0.05;
+
+/** Ignore splits this close to an existing edge (seconds). */
+export const SPLIT_EPSILON = 0.04;
+
 /**
- * Compute the ranges of the original media that have been cut, by merging
- * runs of consecutive deleted words. The silence between two adjacent deleted
- * words is cut too, so deleting a phrase removes it cleanly.
+ * Compute cut ranges from deleted words only (silence between adjacent
+ * deleted words is included).
  */
-export function getCutRanges(words: Word[], duration: number): TimeRange[] {
+export function getWordCutRanges(words: Word[], duration: number): TimeRange[] {
   const ranges: TimeRange[] = [];
   for (let i = 0; i < words.length; i++) {
     const w = words[i];
@@ -21,9 +32,22 @@ export function getCutRanges(words: Word[], duration: number): TimeRange[] {
     }
     ranges.push({ start, end });
   }
-  // Merge ranges separated by less than MERGE_GAP to avoid audible slivers.
+  return mergeCutRanges(ranges, duration);
+}
+
+/** Merge overlapping / near-adjacent ranges and clamp to [0, duration]. */
+export function mergeCutRanges(ranges: TimeRange[], duration: number): TimeRange[] {
+  if (ranges.length === 0) return [];
+  const sorted = [...ranges]
+    .map((r) => ({
+      start: Math.max(0, Math.min(duration, r.start)),
+      end: Math.max(0, Math.min(duration, r.end)),
+    }))
+    .filter((r) => r.end - r.start > 1e-4)
+    .sort((a, b) => a.start - b.start);
+
   const merged: TimeRange[] = [];
-  for (const r of ranges) {
+  for (const r of sorted) {
     const last = merged[merged.length - 1];
     if (last && r.start - last.end < MERGE_GAP) {
       last.end = Math.max(last.end, r.end);
@@ -31,10 +55,21 @@ export function getCutRanges(words: Word[], duration: number): TimeRange[] {
       merged.push({ ...r });
     }
   }
-  return merged.map((r) => ({
-    start: Math.max(0, r.start),
-    end: Math.min(duration, r.end),
-  }));
+  return merged;
+}
+
+/**
+ * All cut ranges: deleted-word spans ∪ manual blade/trim cuts.
+ * Manual cuts may be passed as bare TimeRanges or ManualCut objects.
+ */
+export function getCutRanges(
+  words: Word[],
+  duration: number,
+  manualCuts: Array<TimeRange | ManualCut> = []
+): TimeRange[] {
+  const fromWords = getWordCutRanges(words, duration);
+  const fromManual = manualCuts.map((c) => ({ start: c.start, end: c.end }));
+  return mergeCutRanges([...fromWords, ...fromManual], duration);
 }
 
 /** Invert cut ranges into the ranges of the original media that remain. */
@@ -47,6 +82,43 @@ export function getKeepRanges(cuts: TimeRange[], duration: number): TimeRange[] 
   }
   if (cursor < duration - 1e-4) keeps.push({ start: cursor, end: duration });
   return keeps;
+}
+
+/**
+ * Subdivide keep ranges by scene boundaries into selectable clip segments.
+ * Boundaries that fall inside a cut are ignored for geometry.
+ */
+export function getClipSegments(
+  keepRanges: TimeRange[],
+  sceneBoundaries: SceneBoundary[]
+): ClipSegment[] {
+  const times = sceneBoundaries
+    .map((b) => b.time)
+    .sort((a, b) => a - b);
+
+  const clips: ClipSegment[] = [];
+  for (const keep of keepRanges) {
+    const splits = times.filter(
+      (t) => t > keep.start + SPLIT_EPSILON && t < keep.end - SPLIT_EPSILON
+    );
+    let cursor = keep.start;
+    for (const t of splits) {
+      clips.push({
+        id: `c-${cursor.toFixed(4)}-${t.toFixed(4)}`,
+        start: cursor,
+        end: t,
+        index: clips.length,
+      });
+      cursor = t;
+    }
+    clips.push({
+      id: `c-${cursor.toFixed(4)}-${keep.end.toFixed(4)}`,
+      start: cursor,
+      end: keep.end,
+      index: clips.length,
+    });
+  }
+  return clips;
 }
 
 /** Duration of the edited video (sum of kept ranges). */
@@ -71,6 +143,246 @@ export function cutRangeAt(t: number, cuts: TimeRange[]): TimeRange | null {
     if (t >= cut.start && t < cut.end) return cut;
   }
   return null;
+}
+
+/** Find the clip containing time t, if any. */
+export function clipAt(t: number, clips: ClipSegment[]): ClipSegment | null {
+  for (const c of clips) {
+    if (t >= c.start && t < c.end) return c;
+    // Include exact end of last clip / exact start
+    if (t === c.end && Math.abs(c.end - c.start) > 0) {
+      // Prefer matching start of next; fall through
+    }
+  }
+  // Exact end of media: last clip
+  for (let i = clips.length - 1; i >= 0; i--) {
+    if (t === clips[i].end) return clips[i];
+  }
+  return null;
+}
+
+/**
+ * Whether a split is allowed at time t (inside a keep region, not too close
+ * to existing edges or scene boundaries).
+ */
+export function canSplitAt(
+  t: number,
+  duration: number,
+  cuts: TimeRange[],
+  sceneBoundaries: SceneBoundary[]
+): boolean {
+  if (t <= SPLIT_EPSILON || t >= duration - SPLIT_EPSILON) return false;
+  if (cutRangeAt(t, cuts)) return false;
+  for (const cut of cuts) {
+    if (Math.abs(t - cut.start) < SPLIT_EPSILON || Math.abs(t - cut.end) < SPLIT_EPSILON) {
+      return false;
+    }
+  }
+  for (const b of sceneBoundaries) {
+    if (Math.abs(t - b.time) < SPLIT_EPSILON) return false;
+  }
+  return true;
+}
+
+/**
+ * Clamp a word's new bounds against neighbors.
+ * Returns updated start/end; may steal time from adjacent words when expanding.
+ */
+export function clampWordBounds(
+  words: Word[],
+  index: number,
+  nextStart: number,
+  nextEnd: number,
+  duration: number
+): { start: number; end: number; neighborPatches: Array<{ index: number; start?: number; end?: number }> } {
+  const w = words[index];
+  const minDur = 0.02;
+  let start = Math.max(0, Math.min(nextStart, nextEnd - minDur));
+  let end = Math.min(duration, Math.max(nextEnd, start + minDur));
+
+  const patches: Array<{ index: number; start?: number; end?: number }> = [];
+
+  const prev = index > 0 ? words[index - 1] : null;
+  const next = index < words.length - 1 ? words[index + 1] : null;
+
+  // Hard floor: don't cross into previous word's start
+  if (prev) {
+    const floor = prev.start + minDur;
+    if (start < floor) start = floor;
+    // If we expand left into prev, shrink prev.end
+    if (start < prev.end) {
+      patches.push({ index: index - 1, end: start });
+    }
+  }
+
+  if (next) {
+    const ceil = next.end - minDur;
+    if (end > ceil) end = ceil;
+    if (end > next.start) {
+      patches.push({ index: index + 1, start: end });
+    }
+  }
+
+  if (end - start < minDur) {
+    end = start + minDur;
+  }
+
+  // Re-apply if patches would make neighbor invalid — prefer keeping this word's intent
+  void w;
+  return { start, end, neighborPatches: patches };
+}
+
+/**
+ * Apply word-bound drag: returns a new words array with the target (and
+ * possibly neighbors) updated.
+ */
+export function applyWordBounds(
+  words: Word[],
+  wordId: number,
+  nextStart: number,
+  nextEnd: number,
+  duration: number
+): Word[] | null {
+  const index = words.findIndex((w) => w.id === wordId);
+  if (index < 0) return null;
+  const { start, end, neighborPatches } = clampWordBounds(
+    words,
+    index,
+    nextStart,
+    nextEnd,
+    duration
+  );
+  const cur = words[index];
+  if (Math.abs(cur.start - start) < 1e-4 && Math.abs(cur.end - end) < 1e-4 && neighborPatches.length === 0) {
+    return null;
+  }
+  const next = words.map((w) => ({ ...w }));
+  next[index] = { ...next[index], start, end };
+  for (const p of neighborPatches) {
+    next[p.index] = {
+      ...next[p.index],
+      ...(p.start !== undefined ? { start: p.start } : {}),
+      ...(p.end !== undefined ? { end: p.end } : {}),
+    };
+  }
+  return next;
+}
+
+/**
+ * Shrink or remove manual cuts overlapping [from, to).
+ * When a cut is split into two remnants, `nextId` supplies fresh ids.
+ */
+export function shrinkManualCuts(
+  manualCuts: ManualCut[],
+  from: number,
+  to: number,
+  nextId = 1_000_000
+): { cuts: ManualCut[]; nextId: number } {
+  if (to <= from) return { cuts: manualCuts, nextId };
+  const out: ManualCut[] = [];
+  let id = nextId;
+  for (const c of manualCuts) {
+    if (c.end <= from || c.start >= to) {
+      out.push(c);
+      continue;
+    }
+    if (c.start >= from && c.end <= to) continue;
+    if (c.start < from && c.end > to) {
+      out.push({ ...c, end: from });
+      out.push({ id: id++, start: to, end: c.end });
+      continue;
+    }
+    if (c.start < from) {
+      out.push({ ...c, end: from });
+      continue;
+    }
+    if (c.end > to) {
+      out.push({ ...c, start: to });
+    }
+  }
+  return { cuts: out, nextId: id };
+}
+
+/** Add a manual cut and merge with existing ones that touch. */
+export function addManualCut(
+  manualCuts: ManualCut[],
+  start: number,
+  end: number,
+  nextId: number
+): { cuts: ManualCut[]; nextId: number } {
+  if (end - start < 1e-4) return { cuts: manualCuts, nextId };
+  const merged = mergeCutRanges(
+    [...manualCuts.map((c) => ({ start: c.start, end: c.end })), { start, end }],
+    Number.POSITIVE_INFINITY
+  );
+  // Rebuild with stable-ish ids: keep old ids when a merged range covers an old cut's midpoint
+  let id = nextId;
+  const cuts: ManualCut[] = merged.map((r) => {
+    const existing = manualCuts.find(
+      (c) => c.start >= r.start - 1e-4 && c.end <= r.end + 1e-4
+    );
+    if (existing) return { id: existing.id, start: r.start, end: r.end };
+    return { id: id++, start: r.start, end: r.end };
+  });
+  return { cuts, nextId: id };
+}
+
+/**
+ * Trim one edge of a clip. Shrinking adds a manual cut; expanding shrinks
+ * manual cuts and restores deleted words fully contained in the reclaimed span.
+ */
+export function trimClipEdgeResult(
+  words: Word[],
+  manualCuts: ManualCut[],
+  clip: ClipSegment,
+  edge: "in" | "out",
+  rawTime: number,
+  duration: number,
+  nextCutId: number
+): {
+  words: Word[];
+  manualCuts: ManualCut[];
+  nextCutId: number;
+} | null {
+  let t = Math.max(0, Math.min(duration, rawTime));
+  if (edge === "in") {
+    t = Math.min(t, clip.end - MIN_CLIP_DURATION);
+    t = Math.max(t, 0);
+    if (Math.abs(t - clip.start) < 1e-4) return null;
+
+    if (t > clip.start) {
+      // Shrink: cut [clip.start, t)
+      const { cuts, nextId } = addManualCut(manualCuts, clip.start, t, nextCutId);
+      return { words, manualCuts: cuts, nextCutId: nextId };
+    }
+
+    // Expand left: reclaim [t, clip.start)
+    const shrunk = shrinkManualCuts(manualCuts, t, clip.start, nextCutId);
+    const restored = words.map((w) =>
+      w.deleted && w.start >= t - 1e-4 && w.end <= clip.start + 1e-4
+        ? { ...w, deleted: false }
+        : w
+    );
+    return { words: restored, manualCuts: shrunk.cuts, nextCutId: shrunk.nextId };
+  }
+
+  // out edge
+  t = Math.max(t, clip.start + MIN_CLIP_DURATION);
+  t = Math.min(t, duration);
+  if (Math.abs(t - clip.end) < 1e-4) return null;
+
+  if (t < clip.end) {
+    const { cuts, nextId } = addManualCut(manualCuts, t, clip.end, nextCutId);
+    return { words, manualCuts: cuts, nextCutId: nextId };
+  }
+
+  const shrunk = shrinkManualCuts(manualCuts, clip.end, t, nextCutId);
+  const restored = words.map((w) =>
+    w.deleted && w.start >= clip.end - 1e-4 && w.end <= t + 1e-4
+      ? { ...w, deleted: false }
+      : w
+  );
+  return { words: restored, manualCuts: shrunk.cuts, nextCutId: shrunk.nextId };
 }
 
 /** Format seconds as m:ss.d (or h:mm:ss for long media). */

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -9,7 +9,7 @@
 import type { ModelChoice } from "./models";
 import { isModelChoice } from "./models";
 import type { MediaKind } from "./media";
-import type { Word } from "./types";
+import type { ManualCut, SceneBoundary, Word } from "./types";
 
 const DB_NAME = "rescript-projects";
 const DB_VERSION = 1;
@@ -29,6 +29,10 @@ export interface ProjectMeta {
 export interface ProjectRecord extends ProjectMeta {
   words: Word[];
   showDeleted: boolean;
+  /** Blade/trim cuts not owned by deleted words (optional for older saves). */
+  manualCuts?: ManualCut[];
+  /** Scene split points in original media time (optional for older saves). */
+  sceneBoundaries?: SceneBoundary[];
   /** Original media bytes. */
   media: Blob;
   /** MIME type used when reconstructing a File. */
@@ -123,6 +127,8 @@ export async function putProject(input: ProjectWrite): Promise<string> {
     model: isModelChoice(input.model) ? input.model : "base",
     words: input.words,
     showDeleted: input.showDeleted,
+    manualCuts: input.manualCuts ?? [],
+    sceneBoundaries: input.sceneBoundaries ?? [],
     media: input.media,
     mediaType: input.mediaType,
     createdAt: input.createdAt ?? now,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,7 +1,22 @@
 "use client";
 
 import { create } from "zustand";
-import type { EditorStatus, ProgressInfo, Word } from "./types";
+import type {
+  EditSnapshot,
+  EditorStatus,
+  ManualCut,
+  ProgressInfo,
+  SceneBoundary,
+  Word,
+} from "./types";
+import {
+  applyWordBounds,
+  canSplitAt,
+  getClipSegments,
+  getCutRanges,
+  getKeepRanges,
+  trimClipEdgeResult,
+} from "./edits";
 import {
   isModelChoice,
   isWhisperModel,
@@ -55,9 +70,20 @@ interface EditorState {
 
   // Transcript / edits
   words: Word[];
+  manualCuts: ManualCut[];
+  sceneBoundaries: SceneBoundary[];
   showDeleted: boolean;
-  past: Word[][];
-  future: Word[][];
+  past: EditSnapshot[];
+  future: EditSnapshot[];
+  /** Selected timeline clip index, or null. */
+  selectedClipIndex: number | null;
+  nextManualCutId: number;
+  nextBoundaryId: number;
+  /**
+   * When true, subsequent edit mutations coalesce into the undo entry
+   * created by `beginGesture` (one undo step per drag).
+   */
+  gestureActive: boolean;
 
   // Playback (mirrored from the <video>/<audio> element for UI rendering)
   currentTime: number;
@@ -93,6 +119,23 @@ interface EditorState {
   restoreWords: (ids: number[]) => void;
   /** Replace the selected (contiguous) words with corrected text. */
   correctWords: (ids: number[], text: string) => void;
+  /** Nudge a word's start/end on the timeline (may steal time from neighbors). */
+  adjustWordBounds: (id: number, start: number, end: number) => void;
+  /** Insert a scene boundary at the playhead (Descript-style split). */
+  splitAtPlayhead: () => boolean;
+  /** Remove a scene boundary by id (join adjacent clips). */
+  removeSceneBoundary: (id: number) => void;
+  /** Trim the in or out edge of a clip segment by index. */
+  trimClipEdge: (
+    clipIndex: number,
+    edge: "in" | "out",
+    time: number
+  ) => void;
+  setSelectedClipIndex: (index: number | null) => void;
+  /** Start a drag gesture so subsequent edits share one undo entry. */
+  beginGesture: () => void;
+  /** End the current drag gesture. */
+  endGesture: () => void;
   undo: () => void;
   redo: () => void;
   toggleShowDeleted: () => void;
@@ -107,6 +150,63 @@ interface EditorState {
 function bumpAutosave() {
   // Dynamic import avoids a circular dependency with lib/autosave.ts.
   void import("./autosave").then((m) => m.scheduleProjectAutosave());
+}
+
+function snapshotOf(s: {
+  words: Word[];
+  manualCuts: ManualCut[];
+  sceneBoundaries: SceneBoundary[];
+}): EditSnapshot {
+  return {
+    words: s.words,
+    manualCuts: s.manualCuts,
+    sceneBoundaries: s.sceneBoundaries,
+  };
+}
+
+function snapshotsEqual(a: EditSnapshot, b: EditSnapshot): boolean {
+  return (
+    a.words === b.words &&
+    a.manualCuts === b.manualCuts &&
+    a.sceneBoundaries === b.sceneBoundaries
+  );
+}
+
+function maxId(items: Array<{ id: number }>, fallback = 1): number {
+  return items.reduce((m, x) => Math.max(m, x.id), fallback - 1) + 1;
+}
+
+function pushEdit(
+  get: () => EditorState,
+  set: (
+    partial:
+      | Partial<EditorState>
+      | ((s: EditorState) => Partial<EditorState>)
+  ) => void,
+  next: Partial<
+    Pick<
+      EditorState,
+      | "words"
+      | "manualCuts"
+      | "sceneBoundaries"
+      | "selectedClipIndex"
+      | "nextManualCutId"
+      | "nextBoundaryId"
+    >
+  >
+) {
+  const s = get();
+  if (s.gestureActive) {
+    // Coalesce into the snapshot already pushed by beginGesture.
+    set({ future: [], ...next });
+  } else {
+    set({
+      past: [...s.past, snapshotOf(s)],
+      future: [],
+      ...next,
+    });
+  }
+  bumpAutosave();
 }
 
 export const useEditorStore = create<EditorState>((set, get) => ({
@@ -126,9 +226,15 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   error: null,
 
   words: [],
+  manualCuts: [],
+  sceneBoundaries: [],
   showDeleted: true,
   past: [],
   future: [],
+  selectedClipIndex: null,
+  nextManualCutId: 1,
+  nextBoundaryId: 1,
+  gestureActive: false,
 
   currentTime: 0,
   playing: false,
@@ -159,8 +265,14 @@ export const useEditorStore = create<EditorState>((set, get) => ({
         value: null,
       },
       words: imported ? imported : [],
+      manualCuts: [],
+      sceneBoundaries: [],
       past: [],
       future: [],
+      selectedClipIndex: null,
+      nextManualCutId: 1,
+      nextBoundaryId: 1,
+      gestureActive: false,
       partialText: "",
       error: null,
       currentTime: 0,
@@ -176,6 +288,8 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     const file = fileFromProject(record);
     const prev = get().mediaUrl;
     if (prev) URL.revokeObjectURL(prev);
+    const manualCuts = record.manualCuts ?? [];
+    const sceneBoundaries = record.sceneBoundaries ?? [];
     set({
       videoFile: file,
       mediaUrl: URL.createObjectURL(file),
@@ -188,9 +302,14 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       status: "preparing",
       progress: { message: "Loading media engine…", value: null },
       words: record.words,
+      manualCuts,
+      sceneBoundaries,
       showDeleted: record.showDeleted,
       past: [],
       future: [],
+      selectedClipIndex: null,
+      nextManualCutId: maxId(manualCuts, 1),
+      nextBoundaryId: maxId(sceneBoundaries, 1),
       partialText: "",
       error: null,
       currentTime: 0,
@@ -230,7 +349,14 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   setPartialText: (partialText) => set({ partialText }),
   setError: (message) => set({ status: "error", error: message }),
   setWords: (words) => {
-    set({ words, past: [], future: [] });
+    set({
+      words,
+      manualCuts: [],
+      sceneBoundaries: [],
+      past: [],
+      future: [],
+      selectedClipIndex: null,
+    });
     if (get().status === "ready") bumpAutosave();
   },
   importWords: (words) => {
@@ -247,8 +373,11 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     void import("@/hooks/useTranscriber").then((m) => m.cancelTranscription());
     set({
       words,
+      manualCuts: [],
+      sceneBoundaries: [],
       past: [],
       future: [],
+      selectedClipIndex: null,
       partialText: "",
       error: null,
       status: "ready",
@@ -261,28 +390,26 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
   deleteWords: (ids) => {
     if (ids.length === 0) return;
-    const { words, past } = get();
+    const { words } = get();
     const idSet = new Set(ids);
-    set({
-      past: [...past, words],
-      future: [],
-      words: words.map((w) => (idSet.has(w.id) && !w.deleted ? { ...w, deleted: true } : w)),
+    pushEdit(get, set, {
+      words: words.map((w) =>
+        idSet.has(w.id) && !w.deleted ? { ...w, deleted: true } : w
+      ),
     });
-    bumpAutosave();
   },
   restoreWords: (ids) => {
     if (ids.length === 0) return;
-    const { words, past } = get();
+    const { words } = get();
     const idSet = new Set(ids);
-    set({
-      past: [...past, words],
-      future: [],
-      words: words.map((w) => (idSet.has(w.id) && w.deleted ? { ...w, deleted: false } : w)),
+    pushEdit(get, set, {
+      words: words.map((w) =>
+        idSet.has(w.id) && w.deleted ? { ...w, deleted: false } : w
+      ),
     });
-    bumpAutosave();
   },
   correctWords: (ids, text) => {
-    const { words, past } = get();
+    const { words } = get();
     const tokens = text.split(/\s+/).filter(Boolean);
     if (ids.length === 0 || tokens.length === 0) return;
     const idSet = new Set(ids);
@@ -322,30 +449,118 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     });
     replacement[replacement.length - 1].end = spanEnd;
 
-    set({
-      past: [...past, words],
-      future: [],
+    pushEdit(get, set, {
       words: [...words.slice(0, from), ...replacement, ...words.slice(to + 1)],
     });
-    bumpAutosave();
   },
-  undo: () => {
-    const { past, future, words } = get();
-    if (past.length === 0) return;
+
+  adjustWordBounds: (id, start, end) => {
+    const { words, duration } = get();
+    const next = applyWordBounds(words, id, start, end, duration);
+    if (!next) return;
+    pushEdit(get, set, { words: next });
+  },
+
+  splitAtPlayhead: () => {
+    const s = get();
+    const t = s.currentTime;
+    const cuts = getCutRanges(s.words, s.duration, s.manualCuts);
+    if (!canSplitAt(t, s.duration, cuts, s.sceneBoundaries)) return false;
+    const id = s.nextBoundaryId;
+    pushEdit(get, set, {
+      sceneBoundaries: [...s.sceneBoundaries, { id, time: t }].sort(
+        (a, b) => a.time - b.time
+      ),
+      nextBoundaryId: id + 1,
+    });
+    return true;
+  },
+
+  removeSceneBoundary: (id) => {
+    const { sceneBoundaries } = get();
+    if (!sceneBoundaries.some((b) => b.id === id)) return;
+    pushEdit(get, set, {
+      sceneBoundaries: sceneBoundaries.filter((b) => b.id !== id),
+      selectedClipIndex: null,
+    });
+  },
+
+  trimClipEdge: (clipIndex, edge, time) => {
+    const s = get();
+    const cuts = getCutRanges(s.words, s.duration, s.manualCuts);
+    const keeps = getKeepRanges(cuts, s.duration);
+    const clips = getClipSegments(keeps, s.sceneBoundaries);
+    const clip = clips[clipIndex];
+    if (!clip) return;
+    const result = trimClipEdgeResult(
+      s.words,
+      s.manualCuts,
+      clip,
+      edge,
+      time,
+      s.duration,
+      s.nextManualCutId
+    );
+    if (!result) return;
+    pushEdit(get, set, {
+      words: result.words,
+      manualCuts: result.manualCuts,
+      nextManualCutId: result.nextCutId,
+      selectedClipIndex: clipIndex,
+    });
+  },
+
+  setSelectedClipIndex: (selectedClipIndex) => set({ selectedClipIndex }),
+
+  beginGesture: () => {
+    const s = get();
+    if (s.gestureActive) return;
     set({
-      words: past[past.length - 1],
+      gestureActive: true,
+      past: [...s.past, snapshotOf(s)],
+      future: [],
+    });
+  },
+  endGesture: () => {
+    const s = get();
+    if (!s.gestureActive) return;
+    const last = s.past[s.past.length - 1];
+    if (last && snapshotsEqual(last, snapshotOf(s))) {
+      // No net change — drop the empty undo entry.
+      set({ gestureActive: false, past: s.past.slice(0, -1) });
+    } else {
+      set({ gestureActive: false });
+      bumpAutosave();
+    }
+  },
+
+  undo: () => {
+    const { past, future, words, manualCuts, sceneBoundaries } = get();
+    if (past.length === 0) return;
+    const prev = past[past.length - 1];
+    set({
+      words: prev.words,
+      manualCuts: prev.manualCuts,
+      sceneBoundaries: prev.sceneBoundaries,
       past: past.slice(0, -1),
-      future: [words, ...future],
+      future: [{ words, manualCuts, sceneBoundaries }, ...future],
+      selectedClipIndex: null,
+      gestureActive: false,
     });
     bumpAutosave();
   },
   redo: () => {
-    const { past, future, words } = get();
+    const { past, future, words, manualCuts, sceneBoundaries } = get();
     if (future.length === 0) return;
+    const next = future[0];
     set({
-      words: future[0],
+      words: next.words,
+      manualCuts: next.manualCuts,
+      sceneBoundaries: next.sceneBoundaries,
       future: future.slice(1),
-      past: [...past, words],
+      past: [...past, { words, manualCuts, sceneBoundaries }],
+      selectedClipIndex: null,
+      gestureActive: false,
     });
     bumpAutosave();
   },
@@ -379,8 +594,14 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       partialText: "",
       error: null,
       words: [],
+      manualCuts: [],
+      sceneBoundaries: [],
       past: [],
       future: [],
+      selectedClipIndex: null,
+      nextManualCutId: 1,
+      nextBoundaryId: 1,
+      gestureActive: false,
       currentTime: 0,
       playing: false,
       exportUrl: null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,41 @@ export interface TimeRange {
   end: number;
 }
 
+/**
+ * A user-placed cut that is not owned by a deleted word.
+ * Used for blade/trim edits after splitting clips.
+ */
+export interface ManualCut {
+  id: number;
+  start: number;
+  end: number;
+}
+
+/**
+ * A structural split point in original media time.
+ * Subdivides keep ranges into independently selectable clips (Descript-style scenes).
+ */
+export interface SceneBoundary {
+  id: number;
+  time: number;
+}
+
+/** Snapshot of all edit state for undo/redo. */
+export interface EditSnapshot {
+  words: Word[];
+  manualCuts: ManualCut[];
+  sceneBoundaries: SceneBoundary[];
+}
+
+/** A contiguous kept segment of media, optionally subdivided by scene boundaries. */
+export interface ClipSegment {
+  /** Stable key for React / selection (`start` fixed at creation is not stable after trim). */
+  id: string;
+  start: number;
+  end: number;
+  index: number;
+}
+
 /** Consecutive words spoken by the same speaker (derived for rendering). */
 export interface SpeakerTurn {
   speaker: number;

--- a/scripts/edits-test.ts
+++ b/scripts/edits-test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit checks for flexible clip editing math (word bounds, splits, trims).
+ * Run: npx tsx scripts/edits-test.ts
+ */
+
+import {
+  applyWordBounds,
+  canSplitAt,
+  getClipSegments,
+  getCutRanges,
+  getKeepRanges,
+  getWordCutRanges,
+  trimClipEdgeResult,
+} from "../lib/edits";
+import type { ManualCut, SceneBoundary, Word } from "../lib/types";
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+function word(
+  id: number,
+  text: string,
+  start: number,
+  end: number,
+  deleted = false
+): Word {
+  return { id, text, start, end, speaker: 0, deleted };
+}
+
+function nearly(a: number, b: number, eps = 1e-3) {
+  return Math.abs(a - b) < eps;
+}
+
+// --- Word cuts include silence between adjacent deletes ---
+{
+  const words = [
+    word(1, "hello", 0, 0.5),
+    word(2, "uh", 0.6, 0.8, true),
+    word(3, "everyone", 1.0, 1.5),
+  ];
+  const cuts = getWordCutRanges(words, 2);
+  assert(cuts.length === 1, "one cut from uh");
+  assert(nearly(cuts[0].start, 0.6) && nearly(cuts[0].end, 0.8), "uh span");
+}
+
+// --- Manual cuts merge with word cuts ---
+{
+  const words = [word(1, "a", 0, 1), word(2, "b", 1, 2, true), word(3, "c", 2, 3)];
+  const manual: ManualCut[] = [{ id: 1, start: 2.5, end: 2.7 }];
+  const cuts = getCutRanges(words, 3, manual);
+  assert(cuts.length === 2, `expected 2 cuts, got ${cuts.length}`);
+}
+
+// --- Adjusting uh start away from hello ---
+{
+  const words = [
+    word(1, "hello", 0.0, 0.55),
+    word(2, "uh", 0.45, 0.7), // overlaps hello (ASR bleed)
+    word(3, "everyone", 0.8, 1.2),
+  ];
+  const next = applyWordBounds(words, 2, 0.55, 0.7, 2);
+  assert(next !== null, "bounds applied");
+  assert(nearly(next![1].start, 0.55), "uh starts after hello");
+  assert(nearly(next![0].end, 0.55), "hello end stolen/aligned");
+}
+
+// --- Split subdivides keep ranges ---
+{
+  const words = [word(1, "a", 0, 1), word(2, "b", 1, 2), word(3, "c", 2, 3)];
+  const cuts = getCutRanges(words, 3, []);
+  const keeps = getKeepRanges(cuts, 3);
+  const boundaries: SceneBoundary[] = [{ id: 1, time: 1.5 }];
+  const clips = getClipSegments(keeps, boundaries);
+  assert(clips.length === 2, `expected 2 clips, got ${clips.length}`);
+  assert(nearly(clips[0].end, 1.5) && nearly(clips[1].start, 1.5), "split at 1.5");
+}
+
+// --- canSplitAt rejects cuts ---
+{
+  const words = [word(1, "a", 0, 1, true), word(2, "b", 1, 2)];
+  const cuts = getCutRanges(words, 2, []);
+  assert(!canSplitAt(0.5, 2, cuts, []), "no split inside cut");
+  assert(canSplitAt(1.5, 2, cuts, []), "split inside keep ok");
+}
+
+// --- Trim shrink adds manual cut ---
+{
+  const words = [word(1, "a", 0, 3)];
+  const clip = { id: "c", start: 0, end: 3, index: 0 };
+  const result = trimClipEdgeResult(words, [], clip, "in", 1, 3, 1);
+  assert(result !== null, "trim ok");
+  assert(result!.manualCuts.length === 1, "one manual cut");
+  assert(
+    nearly(result!.manualCuts[0].start, 0) && nearly(result!.manualCuts[0].end, 1),
+    "cut [0,1)"
+  );
+}
+
+console.log("edits-test: all passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a more flexible editing paradigm inspired by Descript: transcript stays primary, but the timeline can refine word timing and split/trim clips independently of whole-word deletes.

## What’s new

**Word timing (fixes ASR bleed)**
- Zoomed wordbar chips with draggable start/end handles
- Expanding a word steals time from neighbors so deleting `uh` no longer eats into `hello`
- Drag gestures coalesce into a single undo step

**Split at playhead**
- Timeline **Split** button + `S` shortcut insert a scene boundary
- Amber markers on the timeline; double-click to join
- Keep ranges subdivide into selectable clips

**Clip trim**
- Hover/select a clip to reveal indigo in/out handles
- Dragging creates **manual cuts** merged with word-derived cuts for preview + export
- Expanding a trim can shrink manual cuts and restore fully covered deleted words

## Data model

- `ManualCut[]` + `SceneBoundary[]` alongside `Word[]`
- Undo/redo snapshots all three; persisted in IndexedDB projects
- `getCutRanges(words, duration, manualCuts)` drives preview and export

## Test plan

- [ ] Transcribe (or import) media; zoom timeline until word chips show handles
- [ ] Drag `uh`’s left edge right so it no longer overlaps `hello`, then Cut — `hello` audio remains
- [ ] Press `S` / Split on a kept region; amber boundary appears; two clips selectable
- [ ] Drag clip trim handles; red cut region updates; playback skips the trim
- [ ] Undo/redo restores a full drag as one step
- [ ] Export includes word cuts + manual trims
- [ ] Reload saved project; splits and manual cuts restore
- [ ] `npx tsx scripts/edits-test.ts` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa8f4-f40c-7cf3-ab43-8f57ca9a9f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa8f4-f40c-7cf3-ab43-8f57ca9a9f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

