### PR TITLE
Make the editor usable on mobile browsers

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -90,10 +90,12 @@ export default function Editor() {
       ) : (
         <>
           <TopBar />
-          <div className="flex min-h-0 flex-1">
-            <TranscriptPanel />
-            <div className="flex w-[44%] min-w-[320px] shrink-0 flex-col border-l border-zinc-200">
+          <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+            <div className="order-1 flex h-[34vh] shrink-0 flex-col border-b border-zinc-200 lg:order-2 lg:h-auto lg:w-[44%] lg:min-w-[320px] lg:border-b-0 lg:border-l">
               <MediaPreview />
+            </div>
+            <div className="order-2 flex min-h-0 flex-1 lg:order-1">
+              <TranscriptPanel />
             </div>
             {/* <SideRail /> — hidden until the tools it exposes are functional */}
           </div>

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -122,10 +122,10 @@ export default function ExportDialog() {
             <a
               href={exportUrl}
               download={fileName}
-              className="flex h-10 items-center justify-center gap-2 rounded-xl bg-neutral-600 text-sm font-medium text-white transition hover:bg-neutral-500"
+              className="flex h-10 items-center justify-center gap-2 rounded-xl bg-neutral-600 px-4 text-sm font-medium text-white transition hover:bg-neutral-500"
             >
-              <Download size={15} />
-              Download {fileName}
+              <Download size={15} className="shrink-0" />
+              <span className="truncate">Download {fileName}</span>
             </a>
             <button
               onClick={start}

--- a/components/MediaPreview.tsx
+++ b/components/MediaPreview.tsx
@@ -96,7 +96,7 @@ export default function MediaPreview() {
   }, []);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-zinc-50/70 p-4">
+    <div className="flex min-h-0 flex-1 flex-col bg-zinc-50/70 p-3 sm:p-4">
       <div className="flex min-h-0 flex-1 items-center justify-center">
         {mediaUrl && isAudio && (
           <>
@@ -139,7 +139,7 @@ export default function MediaPreview() {
       </div>
 
       <div className="mt-3 flex shrink-0 items-center justify-center gap-2">
-        <span className="mr-2 w-28 text-right text-xs tabular-nums text-zinc-500">
+        <span className="mr-1 w-24 text-right text-xs tabular-nums text-zinc-500 sm:mr-2 sm:w-28">
           {formatTime(originalToEdited(currentTime, cuts))}
           <span className="text-zinc-300"> / {formatTime(editedDuration)}</span>
         </span>
@@ -164,7 +164,7 @@ export default function MediaPreview() {
         >
           <SkipForward size={15} />
         </button>
-        <span className="ml-2 w-28 text-xs tabular-nums text-zinc-400">
+        <span className="ml-2 hidden w-28 text-xs tabular-nums text-zinc-400 sm:block">
           {editedDuration < duration - 0.01 && <>original {formatTime(duration)}</>}
         </span>
       </div>

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -164,7 +164,7 @@ export default function Timeline() {
   const playheadX = currentTime * pps - scrollLeft;
 
   return (
-    <footer className="flex h-44 shrink-0 flex-col border-t border-zinc-200 bg-white">
+    <footer className="flex h-32 shrink-0 flex-col border-t border-zinc-200 bg-white sm:h-44">
       <div className="flex h-9 shrink-0 items-center gap-2 border-b border-zinc-100 px-3">
         <span className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
           Timeline

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -304,7 +304,7 @@ export default function TranscriptPanel() {
 
   return (
     <section className="flex min-w-0 flex-1 flex-col bg-white">
-      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-zinc-100 px-4">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-zinc-100 px-3 sm:px-4">
         <span className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
           Transcript
         </span>
@@ -326,7 +326,7 @@ export default function TranscriptPanel() {
               className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100"
             >
               <WandSparkles size={14} />
-              Remove fillers ({fillerIds.length})
+              <span className="hidden sm:inline">Remove fillers </span>({fillerIds.length})
             </button>
           )}
           {(status === "ready" || status === "error" || status === "transcribing") && (
@@ -337,7 +337,7 @@ export default function TranscriptPanel() {
                 className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100"
               >
                 <FileText size={14} />
-                Import
+                <span className="hidden sm:inline">Import</span>
               </button>
               <input
                 ref={importInputRef}
@@ -358,13 +358,15 @@ export default function TranscriptPanel() {
             className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100"
           >
             {showDeleted ? <Eye size={14} /> : <EyeOff size={14} />}
-            {showDeleted ? "Showing cuts" : "Hiding cuts"}
+            <span className="hidden sm:inline">
+              {showDeleted ? "Showing cuts" : "Hiding cuts"}
+            </span>
           </button>
         </div>
       </div>
 
       <div ref={scrollRef} className="relative min-h-0 flex-1 overflow-y-auto">
-        <div ref={containerRef} className="relative mx-auto max-w-2xl px-8 py-8">
+        <div ref={containerRef} className="relative mx-auto max-w-2xl px-4 py-6 sm:px-8 sm:py-8">
           {busy && (
             <div className="flex flex-col items-start gap-4">
               <div className="w-full bg-zinc-50 p-2">


### PR DESCRIPTION
**The** editor's fixed side-by-side split crushed the transcript to a sliver on phones, since the media pane held a 320px minimum. Stack the panes vertically below lg — media on top, transcript filling the rest — and keep the desktop layout untouched.

Collapse the transcript header buttons to icons, trim the media transport labels, shorten the timeline, and tighten padding so nothing overflows on narrow screens.

Before:
<img width="1080" height="2400" alt="Screenshot_2026-07-28-20-08-50-788_com android chrome" src="https://github.com/user-attachments/assets/dcf8c5be-5cfd-4e9f-b04b-0ad5a76c5cb6" />

After:
<img width="894" height="1871" alt="Screenshot_2026-07-28-20-30-29-825_com anthropic claude-edit" src="https://github.com/user-attachments/assets/725a60a5-7779-4829-a1b1-ad7403f6ad30" />
