### PR TITLE
Precise cut trimming: draggable edge handles and scroll-to-zoom

### DIFF
--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { Download, X } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
-import { formatTime, getCutRanges, getEditedDuration, getKeepRanges } from "@/lib/edits";
+import { formatTime, getEditedDuration, getEffectiveCuts, getKeepRanges } from "@/lib/edits";
 import { exportAudio, exportVideo } from "@/lib/ffmpeg";
 
 export default function ExportDialog() {
@@ -13,6 +13,7 @@ export default function ExportDialog() {
   const mediaKind = useEditorStore((s) => s.mediaKind);
   const words = useEditorStore((s) => s.words);
   const duration = useEditorStore((s) => s.duration);
+  const cutAdjustments = useEditorStore((s) => s.cutAdjustments);
   const status = useEditorStore((s) => s.status);
   const setStatus = useEditorStore((s) => s.setStatus);
   const exportUrl = useEditorStore((s) => s.exportUrl);
@@ -21,7 +22,10 @@ export default function ExportDialog() {
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
+  const cuts = useMemo(
+    () => getEffectiveCuts(words, duration, cutAdjustments),
+    [words, duration, cutAdjustments]
+  );
   const editedDuration = useMemo(() => getEditedDuration(cuts, duration), [cuts, duration]);
   const exporting = status === "exporting";
   const isAudio = mediaKind === "audio";

--- a/components/MediaPreview.tsx
+++ b/components/MediaPreview.tsx
@@ -6,8 +6,8 @@ import { useEditorStore } from "@/lib/store";
 import {
   cutRangeAt,
   formatTime,
-  getCutRanges,
   getEditedDuration,
+  getEffectiveCuts,
   originalToEdited,
 } from "@/lib/edits";
 
@@ -17,6 +17,7 @@ export default function MediaPreview() {
   const mediaKind = useEditorStore((s) => s.mediaKind);
   const words = useEditorStore((s) => s.words);
   const duration = useEditorStore((s) => s.duration);
+  const cutAdjustments = useEditorStore((s) => s.cutAdjustments);
   const playing = useEditorStore((s) => s.playing);
   const currentTime = useEditorStore((s) => s.currentTime);
   const setVideoEl = useEditorStore((s) => s.setVideoEl);
@@ -26,7 +27,10 @@ export default function MediaPreview() {
 
   const mediaRef = useRef<HTMLMediaElement | null>(null);
   const isAudio = mediaKind === "audio";
-  const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
+  const cuts = useMemo(
+    () => getEffectiveCuts(words, duration, cutAdjustments),
+    [words, duration, cutAdjustments]
+  );
   const cutsRef = useRef(cuts);
   useEffect(() => {
     cutsRef.current = cuts;

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,14 +1,29 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Maximize2, ZoomIn, ZoomOut } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
-import { formatTime, getCutRanges } from "@/lib/edits";
+import { formatTime, getEffectiveCuts } from "@/lib/edits";
 
 const RULER_H = 20;
 const LABELS_H = 20;
 const SAMPLE_RATE = 16000;
 const TICK_STEPS = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 256;
+/** Wheel-zoom sensitivity (higher = faster zoom per scroll tick). */
+const ZOOM_SPEED = 0.0028;
+/** Grab width (px) of a cut-edge handle's hit area. */
+const HANDLE_HIT = 14;
+/** Smallest cut a drag may leave, so edges never invert. */
+const MIN_CUT = 0.03;
 
 export default function Timeline() {
   const audio = useEditorStore((s) => s.audio);
@@ -16,8 +31,12 @@ export default function Timeline() {
   const duration = useEditorStore((s) => s.duration);
   const currentTime = useEditorStore((s) => s.currentTime);
   const playing = useEditorStore((s) => s.playing);
+  const cutAdjustments = useEditorStore((s) => s.cutAdjustments);
 
-  const cuts = useMemo(() => getCutRanges(words, duration), [words, duration]);
+  const cuts = useMemo(
+    () => getEffectiveCuts(words, duration, cutAdjustments),
+    [words, duration, cutAdjustments]
+  );
 
   const outerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -31,6 +50,23 @@ export default function Timeline() {
   const fitPps = duration > 0 && width > 0 ? width / duration : 50;
   const pps = fitPps * zoom;
   const totalWidth = Math.max(width, duration * pps);
+
+  // Live mirrors for the imperative wheel/drag handlers (avoid stale closures).
+  const ppsRef = useRef(pps);
+  const zoomRef = useRef(zoom);
+  const widthRef = useRef(width);
+  const durationRef = useRef(duration);
+  const cutsRef = useRef(cuts);
+  useEffect(() => {
+    ppsRef.current = pps;
+    zoomRef.current = zoom;
+    widthRef.current = width;
+    durationRef.current = duration;
+    cutsRef.current = cuts;
+  });
+
+  // Scroll position to apply after a wheel-zoom re-renders the track width.
+  const pendingScrollRef = useRef<number | null>(null);
 
   useEffect(() => {
     const el = outerRef.current;
@@ -122,6 +158,51 @@ export default function Timeline() {
     }
   }, [currentTime, playing, pps, width]);
 
+  // Vertical wheel / pinch zooms (anchored at the pointer so the point under
+  // the cursor stays put); horizontal trackpad side-scroll pans the track by
+  // letting the browser scroll the overflow-x container natively. Registered
+  // as a non-passive listener so the zoom branch can preventDefault.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (durationRef.current <= 0) return;
+      // Horizontal intent → pan: don't preventDefault, let native scroll run.
+      if (!e.ctrlKey && Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+      e.preventDefault();
+      const curZoom = zoomRef.current;
+      const curPps = ppsRef.current;
+      if (curPps <= 0) return;
+      const rect = el.getBoundingClientRect();
+      const pointerX = e.clientX - rect.left;
+      const tAnchor = (el.scrollLeft + pointerX) / curPps;
+      const nextZoom = Math.min(
+        MAX_ZOOM,
+        Math.max(MIN_ZOOM, curZoom * Math.exp(-e.deltaY * ZOOM_SPEED))
+      );
+      if (nextZoom === curZoom) return;
+      const fit =
+        widthRef.current > 0 && durationRef.current > 0
+          ? widthRef.current / durationRef.current
+          : 50;
+      const nextPps = fit * nextZoom;
+      pendingScrollRef.current = Math.max(0, tAnchor * nextPps - pointerX);
+      setZoom(nextZoom);
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
+  // Apply the anchor-preserving scroll once the wheel-zoom has re-rendered the
+  // (wider/narrower) track. Runs before paint to avoid a visible jump.
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el || pendingScrollRef.current == null) return;
+    el.scrollLeft = pendingScrollRef.current;
+    pendingScrollRef.current = null;
+    setScrollLeft(el.scrollLeft);
+  }, [zoom]);
+
   const seekFromPointer = useCallback(
     (clientX: number) => {
       const el = scrollRef.current;
@@ -153,6 +234,74 @@ export default function Timeline() {
     [seekFromPointer]
   );
 
+  // --- Cut-edge handle dragging ------------------------------------------
+  const dragRef = useRef<{ key: number; edge: "start" | "end"; pushed: boolean } | null>(
+    null
+  );
+
+  const timeFromClientX = useCallback((clientX: number) => {
+    const el = scrollRef.current;
+    if (!el || ppsRef.current <= 0) return 0;
+    const rect = el.getBoundingClientRect();
+    return (clientX - rect.left + el.scrollLeft) / ppsRef.current;
+  }, []);
+
+  const onHandleDown = useCallback(
+    (e: React.PointerEvent, key: number, edge: "start" | "end") => {
+      e.stopPropagation();
+      e.preventDefault();
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      dragRef.current = { key, edge, pushed: false };
+    },
+    []
+  );
+
+  const onHandleMove = useCallback(
+    (e: React.PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      e.stopPropagation();
+      const list = cutsRef.current;
+      const idx = list.findIndex((c) => c.key === drag.key);
+      if (idx === -1) return;
+      const cut = list[idx];
+      const prev = list[idx - 1];
+      const next = list[idx + 1];
+      let t = timeFromClientX(e.clientX);
+      if (drag.edge === "start") {
+        const lo = prev ? prev.end : 0;
+        const hi = Math.max(lo, cut.end - MIN_CUT);
+        t = Math.min(Math.max(t, lo), hi);
+      } else {
+        const hi = next ? next.start : durationRef.current;
+        const lo = Math.min(hi, cut.start + MIN_CUT);
+        t = Math.min(Math.max(t, lo), hi);
+      }
+      const { adjustCut, videoEl, setCurrentTime } = useEditorStore.getState();
+      adjustCut(drag.key, drag.edge, t, !drag.pushed);
+      drag.pushed = true;
+      // Scrub the preview to the edge for precise, audible/visible trimming.
+      if (videoEl) videoEl.currentTime = t;
+      setCurrentTime(t);
+    },
+    [timeFromClientX]
+  );
+
+  const onHandleUp = useCallback((e: React.PointerEvent) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    const el = e.currentTarget as HTMLElement;
+    if (el.hasPointerCapture?.(e.pointerId)) el.releasePointerCapture(e.pointerId);
+  }, []);
+
+  const onHandleReset = useCallback(
+    (e: React.MouseEvent, key: number) => {
+      e.stopPropagation();
+      useEditorStore.getState().resetCutAdjust(key);
+    },
+    []
+  );
+
   // Word labels for the visible window (only when zoomed in enough to read).
   const visibleWords = useMemo(() => {
     if (pps < 18) return [];
@@ -161,7 +310,16 @@ export default function Timeline() {
     return words.filter((w) => w.end >= t0 && w.start <= t1);
   }, [words, pps, scrollLeft, width]);
 
+  // Only mount handles for cuts intersecting the viewport (bounds DOM nodes).
+  const visibleCuts = useMemo(() => {
+    if (width === 0) return cuts;
+    const t0 = scrollLeft / pps - 1;
+    const t1 = (scrollLeft + width) / pps + 1;
+    return cuts.filter((c) => c.end >= t0 && c.start <= t1);
+  }, [cuts, pps, scrollLeft, width]);
+
   const playheadX = currentTime * pps - scrollLeft;
+  const handleTop = RULER_H;
 
   return (
     <footer className="flex h-44 shrink-0 flex-col border-t border-zinc-200 bg-white">
@@ -170,9 +328,12 @@ export default function Timeline() {
           Timeline
         </span>
         <span className="text-xs tabular-nums text-zinc-400">{formatTime(currentTime)}</span>
+        <span className="hidden text-[11px] text-zinc-300 sm:inline">
+          scroll to zoom · side-scroll to pan · drag cut edges to trim
+        </span>
         <div className="ml-auto flex items-center gap-0.5">
           <button
-            onClick={() => setZoom((z) => Math.max(1, z / 1.5))}
+            onClick={() => setZoom((z) => Math.max(MIN_ZOOM, z / 1.5))}
             title="Zoom out"
             className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-zinc-100"
           >
@@ -186,7 +347,7 @@ export default function Timeline() {
             <Maximize2 size={13} />
           </button>
           <button
-            onClick={() => setZoom((z) => Math.min(256, z * 1.5))}
+            onClick={() => setZoom((z) => Math.min(MAX_ZOOM, z * 1.5))}
             title="Zoom in"
             className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-500 transition hover:bg-zinc-100"
           >
@@ -225,6 +386,43 @@ export default function Timeline() {
                 {w.text}
               </span>
             ))}
+
+            {visibleCuts.map((cut) => {
+              const adjusted = Boolean(cutAdjustments[cut.key]);
+              return (
+                <div key={cut.key}>
+                  {(["start", "end"] as const).map((edge) => (
+                    <div
+                      key={edge}
+                      aria-label={`Drag to trim cut ${edge}`}
+                      onPointerDown={(e) => onHandleDown(e, cut.key, edge)}
+                      onPointerMove={onHandleMove}
+                      onPointerUp={onHandleUp}
+                      onPointerCancel={onHandleUp}
+                      onDoubleClick={(e) => onHandleReset(e, cut.key)}
+                      title={
+                        adjusted
+                          ? `Drag to trim · double-click to reset (cut ${edge})`
+                          : `Drag to trim the cut ${edge}`
+                      }
+                      className="group absolute z-20 flex touch-none cursor-ew-resize justify-center"
+                      style={{
+                        left: cut[edge] * pps - HANDLE_HIT / 2,
+                        top: handleTop,
+                        bottom: 0,
+                        width: HANDLE_HIT,
+                      }}
+                    >
+                      <span
+                        className={`pointer-events-none h-full w-0.5 rounded-full transition-colors group-hover:w-1 ${
+                          adjusted ? "bg-red-500" : "bg-red-400/70 group-hover:bg-red-500"
+                        }`}
+                      />
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
           </div>
         </div>
 

--- a/lib/autosave.ts
+++ b/lib/autosave.ts
@@ -64,6 +64,7 @@ async function writeSnapshot() {
       model: s.model,
       words: s.words,
       showDeleted: s.showDeleted,
+      cutAdjustments: s.cutAdjustments,
       media: s.videoFile,
       mediaType: s.videoFile.type,
       createdAt,

--- a/lib/edits.ts
+++ b/lib/edits.ts
@@ -1,4 +1,4 @@
-import type { TimeRange, Word } from "./types";
+import type { CutAdjustments, CutRange, TimeRange, Word } from "./types";
 
 /** Padding (s) applied when merging adjacent deleted words into one cut. */
 const MERGE_GAP = 0.35;
@@ -8,21 +8,25 @@ const MERGE_GAP = 0.35;
  * runs of consecutive deleted words. The silence between two adjacent deleted
  * words is cut too, so deleting a phrase removes it cleanly.
  */
-export function getCutRanges(words: Word[], duration: number): TimeRange[] {
-  const ranges: TimeRange[] = [];
+export function getCutRanges(words: Word[], duration: number): CutRange[] {
+  const ranges: CutRange[] = [];
   for (let i = 0; i < words.length; i++) {
     const w = words[i];
     if (!w.deleted) continue;
+    // Anchor the cut to the first deleted word's id so a manual edge
+    // adjustment can be attached to this cut specifically.
+    const key = w.id;
     const start = w.start;
     let end = w.end;
     while (i + 1 < words.length && words[i + 1].deleted) {
       i++;
       end = Math.max(end, words[i].end);
     }
-    ranges.push({ start, end });
+    ranges.push({ start, end, key });
   }
   // Merge ranges separated by less than MERGE_GAP to avoid audible slivers.
-  const merged: TimeRange[] = [];
+  // The earlier range's key is kept so the merged cut has a stable anchor.
+  const merged: CutRange[] = [];
   for (const r of ranges) {
     const last = merged[merged.length - 1];
     if (last && r.start - last.end < MERGE_GAP) {
@@ -32,9 +36,56 @@ export function getCutRanges(words: Word[], duration: number): TimeRange[] {
     }
   }
   return merged.map((r) => ({
+    ...r,
     start: Math.max(0, r.start),
     end: Math.min(duration, r.end),
   }));
+}
+
+/**
+ * Apply manual cut-edge overrides on top of the word-derived cuts. An override
+ * replaces either edge with an absolute time (in original media seconds);
+ * unset edges keep tracking the word boundary. The result is re-sorted and made
+ * non-overlapping so downstream keep-range / playback logic stays well-formed.
+ */
+export function applyCutAdjustments(
+  cuts: CutRange[],
+  adjustments: CutAdjustments,
+  duration: number
+): CutRange[] {
+  const clamp = (t: number) => Math.min(Math.max(0, t), duration);
+  const adjusted = cuts.map((c) => {
+    const a = adjustments[c.key];
+    if (!a) return { ...c };
+    const start = clamp(a.start ?? c.start);
+    let end = clamp(a.end ?? c.end);
+    if (end < start) end = start;
+    return { ...c, start, end };
+  });
+  adjusted.sort((a, b) => a.start - b.start);
+  for (let i = 1; i < adjusted.length; i++) {
+    if (adjusted[i].start < adjusted[i - 1].end) {
+      adjusted[i].start = adjusted[i - 1].end;
+    }
+    if (adjusted[i].end < adjusted[i].start) {
+      adjusted[i].end = adjusted[i].start;
+    }
+  }
+  return adjusted;
+}
+
+/**
+ * The cuts actually used for rendering, playback and export: word-derived cuts
+ * with any manual edge adjustments applied.
+ */
+export function getEffectiveCuts(
+  words: Word[],
+  duration: number,
+  adjustments: CutAdjustments = {}
+): CutRange[] {
+  const cuts = getCutRanges(words, duration);
+  if (!adjustments || Object.keys(adjustments).length === 0) return cuts;
+  return applyCutAdjustments(cuts, adjustments, duration);
 }
 
 /** Invert cut ranges into the ranges of the original media that remain. */

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -9,7 +9,7 @@
 import type { ModelChoice } from "./models";
 import { isModelChoice } from "./models";
 import type { MediaKind } from "./media";
-import type { Word } from "./types";
+import type { CutAdjustments, Word } from "./types";
 
 const DB_NAME = "rescript-projects";
 const DB_VERSION = 1;
@@ -29,6 +29,8 @@ export interface ProjectMeta {
 export interface ProjectRecord extends ProjectMeta {
   words: Word[];
   showDeleted: boolean;
+  /** Manual cut-edge overrides (optional; absent on projects saved before this feature). */
+  cutAdjustments?: CutAdjustments;
   /** Original media bytes. */
   media: Blob;
   /** MIME type used when reconstructing a File. */
@@ -123,6 +125,7 @@ export async function putProject(input: ProjectWrite): Promise<string> {
     model: isModelChoice(input.model) ? input.model : "base",
     words: input.words,
     showDeleted: input.showDeleted,
+    cutAdjustments: input.cutAdjustments ?? {},
     media: input.media,
     mediaType: input.mediaType,
     createdAt: input.createdAt ?? now,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { create } from "zustand";
-import type { EditorStatus, ProgressInfo, Word } from "./types";
+import type { CutAdjustments, EditorStatus, ProgressInfo, Word } from "./types";
 import {
   isModelChoice,
   isWhisperModel,
@@ -20,6 +20,15 @@ import {
 interface PendingTranscript {
   name: string;
   words: Word[];
+}
+
+/**
+ * A unit of undoable editor state. Cut-edge adjustments are versioned
+ * alongside word edits so a manual trim undoes/redoes like any other edit.
+ */
+interface Snapshot {
+  words: Word[];
+  cutAdjustments: CutAdjustments;
 }
 
 interface EditorState {
@@ -56,8 +65,10 @@ interface EditorState {
   // Transcript / edits
   words: Word[];
   showDeleted: boolean;
-  past: Word[][];
-  future: Word[][];
+  /** Manual cut-edge overrides, keyed by CutRange.key (see lib/edits.ts). */
+  cutAdjustments: CutAdjustments;
+  past: Snapshot[];
+  future: Snapshot[];
 
   // Playback (mirrored from the <video>/<audio> element for UI rendering)
   currentTime: number;
@@ -93,6 +104,14 @@ interface EditorState {
   restoreWords: (ids: number[]) => void;
   /** Replace the selected (contiguous) words with corrected text. */
   correctWords: (ids: number[], text: string) => void;
+  /**
+   * Set one edge of a cut's manual override (absolute time in original media
+   * seconds). Pass `commit: true` on the first change of a drag to open a new
+   * undo step; `false` for subsequent moves so the whole drag is one undo.
+   */
+  adjustCut: (key: number, edge: "start" | "end", time: number, commit: boolean) => void;
+  /** Clear a cut's manual override, reverting it to the word-derived edges. */
+  resetCutAdjust: (key: number) => void;
   undo: () => void;
   redo: () => void;
   toggleShowDeleted: () => void;
@@ -107,6 +126,11 @@ interface EditorState {
 function bumpAutosave() {
   // Dynamic import avoids a circular dependency with lib/autosave.ts.
   void import("./autosave").then((m) => m.scheduleProjectAutosave());
+}
+
+/** Capture the current undoable state (words + cut adjustments). */
+function snapshotOf(s: { words: Word[]; cutAdjustments: CutAdjustments }): Snapshot {
+  return { words: s.words, cutAdjustments: s.cutAdjustments };
 }
 
 export const useEditorStore = create<EditorState>((set, get) => ({
@@ -127,6 +151,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
   words: [],
   showDeleted: true,
+  cutAdjustments: {},
   past: [],
   future: [],
 
@@ -159,6 +184,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
         value: null,
       },
       words: imported ? imported : [],
+      cutAdjustments: {},
       past: [],
       future: [],
       partialText: "",
@@ -189,6 +215,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       progress: { message: "Loading media engine…", value: null },
       words: record.words,
       showDeleted: record.showDeleted,
+      cutAdjustments: record.cutAdjustments ?? {},
       past: [],
       future: [],
       partialText: "",
@@ -230,7 +257,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   setPartialText: (partialText) => set({ partialText }),
   setError: (message) => set({ status: "error", error: message }),
   setWords: (words) => {
-    set({ words, past: [], future: [] });
+    set({ words, cutAdjustments: {}, past: [], future: [] });
     if (get().status === "ready") bumpAutosave();
   },
   importWords: (words) => {
@@ -247,6 +274,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     void import("@/hooks/useTranscriber").then((m) => m.cancelTranscription());
     set({
       words,
+      cutAdjustments: {},
       past: [],
       future: [],
       partialText: "",
@@ -264,7 +292,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     const { words, past } = get();
     const idSet = new Set(ids);
     set({
-      past: [...past, words],
+      past: [...past, snapshotOf(get())],
       future: [],
       words: words.map((w) => (idSet.has(w.id) && !w.deleted ? { ...w, deleted: true } : w)),
     });
@@ -275,7 +303,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     const { words, past } = get();
     const idSet = new Set(ids);
     set({
-      past: [...past, words],
+      past: [...past, snapshotOf(get())],
       future: [],
       words: words.map((w) => (idSet.has(w.id) && w.deleted ? { ...w, deleted: false } : w)),
     });
@@ -323,29 +351,58 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     replacement[replacement.length - 1].end = spanEnd;
 
     set({
-      past: [...past, words],
+      past: [...past, snapshotOf(get())],
       future: [],
       words: [...words.slice(0, from), ...replacement, ...words.slice(to + 1)],
     });
     bumpAutosave();
   },
-  undo: () => {
-    const { past, future, words } = get();
-    if (past.length === 0) return;
+  adjustCut: (key, edge, time, commit) => {
+    const { cutAdjustments, past } = get();
+    const nextAdjustments: CutAdjustments = {
+      ...cutAdjustments,
+      [key]: { ...(cutAdjustments[key] ?? {}), [edge]: time },
+    };
     set({
-      words: past[past.length - 1],
+      cutAdjustments: nextAdjustments,
+      // Open a new undo step only on the first change of a drag.
+      ...(commit ? { past: [...past, snapshotOf(get())], future: [] } : {}),
+    });
+    bumpAutosave();
+  },
+  resetCutAdjust: (key) => {
+    const { cutAdjustments, past } = get();
+    if (!cutAdjustments[key]) return;
+    const nextAdjustments = { ...cutAdjustments };
+    delete nextAdjustments[key];
+    set({
+      past: [...past, snapshotOf(get())],
+      future: [],
+      cutAdjustments: nextAdjustments,
+    });
+    bumpAutosave();
+  },
+  undo: () => {
+    const { past, future } = get();
+    if (past.length === 0) return;
+    const prev = past[past.length - 1];
+    set({
+      words: prev.words,
+      cutAdjustments: prev.cutAdjustments,
       past: past.slice(0, -1),
-      future: [words, ...future],
+      future: [snapshotOf(get()), ...future],
     });
     bumpAutosave();
   },
   redo: () => {
-    const { past, future, words } = get();
+    const { past, future } = get();
     if (future.length === 0) return;
+    const next = future[0];
     set({
-      words: future[0],
+      words: next.words,
+      cutAdjustments: next.cutAdjustments,
+      past: [...past, snapshotOf(get())],
       future: future.slice(1),
-      past: [...past, words],
     });
     bumpAutosave();
   },
@@ -379,6 +436,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       partialText: "",
       error: null,
       words: [],
+      cutAdjustments: {},
       past: [],
       future: [],
       currentTime: 0,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,28 @@ export interface TimeRange {
   end: number;
 }
 
+/**
+ * A cut range tagged with a stable `key` (the id of the first deleted word in
+ * the run that produced it), so manual edge adjustments can be attached to a
+ * specific cut even as the derived set changes.
+ */
+export interface CutRange extends TimeRange {
+  key: number;
+}
+
+/**
+ * A manual override of a cut's edges, in original media seconds. Either edge
+ * may be set independently; an unset edge tracks the word-derived boundary.
+ * Lets the user trim a cut more precisely than Whisper's word timestamps allow.
+ */
+export interface CutAdjustment {
+  start?: number;
+  end?: number;
+}
+
+/** Manual cut-edge overrides, keyed by CutRange.key. */
+export type CutAdjustments = Record<number, CutAdjustment>;
+
 /** Consecutive words spoken by the same speaker (derived for rendering). */
 export interface SpeakerTurn {
   speaker: number;


### PR DESCRIPTION
Two small features for getting cuts exactly right.

### Draggable cut edges
Grab either edge of a cut in the timeline and drag to trim, independent of word timestamps. Fixes clipped or half-included words when Whisper timing is slightly off.

- Drag scrubs the preview to the edge so you can land it precisely
- Double-click an edge to reset it to the word boundary

### Scroll to zoom, side-scroll to pan
- Vertical wheel and pinch zoom at the cursor
- Horizontal scroll pans the track

### How it works
- Cuts still derive from deleted words. Each cut gets a stable key plus an optional edge override.
- One selector, getEffectiveCuts, applies overrides everywhere: timeline, live playback, and export.
- Overrides are undoable and persisted with the project (IndexedDB).

### Notes
- No new dependencies
- Default behavior is unchanged when nothing is adjusted
- lint and build pass
