### PR TITLE
Readability cleanup: dedupe helpers, naming, and dead code

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import { isElectron } from "@/lib/platform";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -15,9 +16,6 @@ const geistMono = Geist_Mono({
 });
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-/** Set at desktop static-export time so we skip the COI service worker
- *  (the Electron `app://` protocol sets COOP/COEP headers directly). */
-const isElectron = /electron/i.test(navigator.userAgent);
 
 const title = "Rescript — edit videos like you edit text";
 const description =

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { useEditorStore } from "@/lib/store";
 import { extractAudio, getFFmpeg } from "@/lib/ffmpeg";
+import { VAD_SAMPLE_RATE } from "@/lib/vad";
+import { isElectron } from "@/lib/platform";
 import { useTranscriber } from "@/hooks/useTranscriber";
 import TopBar from "./TopBar";
 import UploadScreen from "./UploadScreen";
@@ -141,7 +143,6 @@ export default function Editor() {
   const redo = useEditorStore((s) => s.redo);
   const setExportOpen = useEditorStore((s) => s.setExportOpen);
 
-  const isElectron = /electron/i.test(navigator.userAgent);
   const [modeTransitioning, setModeTransitioning] = useState(false);
   const wasIdle = useRef(status === "idle");
 
@@ -164,7 +165,7 @@ export default function Editor() {
           s.setStatus("ready");
           s.setProgress({ message: "", value: null });
         } else {
-          transcribe(audio, audio.length / 16000);
+          transcribe(audio, audio.length / VAD_SAMPLE_RATE);
         }
       } catch (err) {
         console.error("Processing pipeline failed:", err);
@@ -185,7 +186,7 @@ export default function Editor() {
     setModeTransitioning(true);
     const timer = window.setTimeout(() => setModeTransitioning(false), WINDOW_MODE_OVERLAY_MS);
     return () => window.clearTimeout(timer);
-  }, [status, isElectron]);
+  }, [status]);
 
   // Global shortcuts: space = play/pause, ⌘Z / ⇧⌘Z = undo / redo, S = split.
   // Capture phase so Space is ours before a focused <button> synthesizes a click

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -3,16 +3,15 @@
 import { useCallback, useMemo, useState } from "react";
 import { Download, X } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
-import { formatTime, getCutRanges, getEditedDuration, getKeepRanges } from "@/lib/edits";
+import { formatTime, getEditedDuration, getKeepRanges } from "@/lib/edits";
 import { exportAudio, exportVideo } from "@/lib/ffmpeg";
+import { useCutRanges } from "@/hooks/useCutRanges";
 
 export default function ExportDialog() {
   const open = useEditorStore((s) => s.exportOpen);
   const setOpen = useEditorStore((s) => s.setExportOpen);
   const videoFile = useEditorStore((s) => s.videoFile);
   const mediaKind = useEditorStore((s) => s.mediaKind);
-  const words = useEditorStore((s) => s.words);
-  const manualCuts = useEditorStore((s) => s.manualCuts);
   const duration = useEditorStore((s) => s.duration);
   const status = useEditorStore((s) => s.status);
   const setStatus = useEditorStore((s) => s.setStatus);
@@ -22,10 +21,7 @@ export default function ExportDialog() {
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  const cuts = useMemo(
-    () => getCutRanges(words, duration, manualCuts),
-    [words, duration, manualCuts]
-  );
+  const cuts = useCutRanges();
   const editedDuration = useMemo(() => getEditedDuration(cuts, duration), [cuts, duration]);
   const exporting = status === "exporting";
   const isAudio = mediaKind === "audio";

--- a/components/ImportTranscriptOption.tsx
+++ b/components/ImportTranscriptOption.tsx
@@ -5,6 +5,7 @@ import { FileText, Loader2 } from "lucide-react";
 import {
   isTranscriptFile,
   parseTranscriptFile,
+  TRANSCRIPT_FILE_ERROR,
   TRANSCRIPT_ACCEPT,
 } from "@/lib/parseTranscript";
 import { isWhisperModel } from "@/lib/models";
@@ -128,7 +129,7 @@ export default function ImportTranscriptOption() {
             }
             if (!isTranscriptFile(file)) {
               setPicking(false);
-              setError("Choose an SRT, VTT, or JSON file.");
+              setError(TRANSCRIPT_FILE_ERROR);
               setPendingTranscript(null);
               setModel("import");
               menu?.keepMenuOpen();

--- a/components/MediaPreview.tsx
+++ b/components/MediaPreview.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useRef } from "react";
 import { useEditorStore } from "@/lib/store";
-import { cutRangeAt, getCutRanges } from "@/lib/edits";
+import { cutRangeAt, PLAYHEAD_EPSILON_S } from "@/lib/edits";
+import { useCutRanges } from "@/hooks/useCutRanges";
 
 /**
  * Owns the <video>/<audio> element and the cut-skipping playback loop.
@@ -12,20 +13,18 @@ import { cutRangeAt, getCutRanges } from "@/lib/edits";
 export default function MediaPreview() {
   const mediaUrl = useEditorStore((s) => s.mediaUrl);
   const mediaKind = useEditorStore((s) => s.mediaKind);
-  const words = useEditorStore((s) => s.words);
-  const manualCuts = useEditorStore((s) => s.manualCuts);
-  const duration = useEditorStore((s) => s.duration);
   const setVideoEl = useEditorStore((s) => s.setVideoEl);
   const setDuration = useEditorStore((s) => s.setDuration);
   const setPlaying = useEditorStore((s) => s.setPlaying);
   const setCurrentTime = useEditorStore((s) => s.setCurrentTime);
+  const cuts = useCutRanges();
 
   const mediaRef = useRef<HTMLMediaElement | null>(null);
   const isAudio = mediaKind === "audio";
-  const cutsRef = useRef(getCutRanges(words, duration, manualCuts));
+  const cutsRef = useRef(cuts);
   useEffect(() => {
-    cutsRef.current = getCutRanges(words, duration, manualCuts);
-  }, [words, duration, manualCuts]);
+    cutsRef.current = cuts;
+  }, [cuts]);
 
   const refCb = useCallback(
     (el: HTMLMediaElement | null) => {
@@ -45,7 +44,7 @@ export default function MediaPreview() {
         if (!media.paused) {
           const cut = cutRangeAt(t, cutsRef.current);
           if (cut) {
-            const target = cut.end + 0.001;
+            const target = cut.end + PLAYHEAD_EPSILON_S;
             if (target >= media.duration - 0.05) {
               media.pause();
               media.currentTime = cut.start;

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -10,20 +10,12 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import {
-  ChevronFirst,
-  ChevronLast,
   ChevronLeft,
   ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
   Maximize2,
   Merge,
   Pause,
   Play,
-  RotateCcwClock,
-  RotateCcwSquare,
-  RotateCwFadingClock,
-  RotateCwSquare,
   SquareSplitHorizontal,
   ZoomIn,
   ZoomOut,
@@ -34,7 +26,6 @@ import {
   formatTime,
   getActiveSceneBoundaries,
   getClipSegments,
-  getCutRanges,
   getEditedDuration,
   getKeepRanges,
   isWordCutOut,
@@ -42,10 +33,11 @@ import {
   trimEdgeBounds,
 } from "@/lib/edits";
 import type { ClipSegment, Word } from "@/lib/types";
+import { VAD_SAMPLE_RATE } from "@/lib/vad";
+import { useCutRanges } from "@/hooks/useCutRanges";
 
 const RULER_H = 18;
 const WORDBAR_H = 28;
-const SAMPLE_RATE = 16000;
 const TICK_STEPS = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
 /** Pixels-per-second below which the timeline is considered "small". */
 const SMALL_PPS = 22;
@@ -71,7 +63,6 @@ type DragKind =
 export default function Timeline() {
   const audio = useEditorStore((s) => s.audio);
   const words = useEditorStore((s) => s.words);
-  const manualCuts = useEditorStore((s) => s.manualCuts);
   const sceneBoundaries = useEditorStore((s) => s.sceneBoundaries);
   const duration = useEditorStore((s) => s.duration);
   const currentTime = useEditorStore((s) => s.currentTime);
@@ -80,10 +71,7 @@ export default function Timeline() {
   const selectedWordIds = useEditorStore((s) => s.selectedWordIds);
   const status = useEditorStore((s) => s.status);
 
-  const cuts = useMemo(
-    () => getCutRanges(words, duration, manualCuts),
-    [words, duration, manualCuts]
-  );
+  const cuts = useCutRanges();
   const keeps = useMemo(() => getKeepRanges(cuts, duration), [cuts, duration]);
   const clips = useMemo(
     () => getClipSegments(keeps, sceneBoundaries),
@@ -235,12 +223,12 @@ export default function Timeline() {
     }
 
     // Waveform
-    const samplesPerPx = SAMPLE_RATE / pps;
+    const samplesPerPx = VAD_SAMPLE_RATE / pps;
     const stride = Math.max(1, Math.floor(samplesPerPx / 40));
     for (let x = 0; x < width; x++) {
       const t = (scrollLeft + x) / pps;
       if (t > duration) break;
-      const i0 = Math.floor(t * SAMPLE_RATE);
+      const i0 = Math.floor(t * VAD_SAMPLE_RATE);
       const i1 = Math.min(audio.length, Math.floor(i0 + samplesPerPx) + 1);
       let min = 0;
       let max = 0;
@@ -335,9 +323,7 @@ export default function Timeline() {
   );
 
   const seekTo = useCallback((t: number) => {
-    const { videoEl, setCurrentTime } = useEditorStore.getState();
-    if (videoEl) videoEl.currentTime = t;
-    setCurrentTime(t);
+    useEditorStore.getState().seekTo(t);
   }, []);
 
   const endDrag = useCallback(() => {
@@ -473,11 +459,6 @@ export default function Timeline() {
     [cuts]
   );
 
-  const doSplit = useCallback(() => {
-    const ok = useEditorStore.getState().splitAtPlayhead();
-    if (!ok) return;
-  }, []);
-
   const editedDuration = useMemo(
     () => getEditedDuration(cuts, duration),
     [cuts, duration]
@@ -564,7 +545,9 @@ export default function Timeline() {
           <button
             type="button"
             disabled={!ready || !splitOk}
-            onClick={doSplit}
+            onClick={() => {
+              useEditorStore.getState().splitAtPlayhead();
+            }}
             title={
               splitOk
                 ? "Split clip at playhead (S)"

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -17,20 +17,22 @@ import { findFillerWordIds } from "@/lib/fillers";
 import {
   isTranscriptFile,
   parseTranscriptFile,
+  TRANSCRIPT_FILE_ERROR,
   TRANSCRIPT_ACCEPT,
 } from "@/lib/parseTranscript";
-import type { SpeakerTurn, Word } from "@/lib/types";
+import type { Word } from "@/lib/types";
 import TranscriptScrollIndicator from "./TranscriptScrollIndicator";
 import {
   getActiveSceneBoundaries,
-  getCutRanges,
   getKeepRanges,
   isWordCutOut,
   mapSplitsToWords,
 } from "@/lib/edits";
 import { useTranscriptSelection } from "@/hooks/useTranscriptSelection";
+import { useCutRanges } from "@/hooks/useCutRanges";
+import { findActiveWordId, groupWordsBySpeaker } from "@/lib/transcript";
 
-export const SPEAKER_COLORS = [
+const SPEAKER_COLORS = [
   "#16a34a", // green
   "#2563eb", // blue
   "#9333ea", // purple
@@ -39,26 +41,8 @@ export const SPEAKER_COLORS = [
   "#db2777", // pink
 ];
 
-export const speakerColor = (i: number) =>
+const speakerColor = (i: number) =>
   SPEAKER_COLORS[Math.max(0, i) % SPEAKER_COLORS.length];
-
-function findActiveWordId(words: Word[], t: number): number {
-  // Binary search for the last word starting at or before t.
-  let lo = 0;
-  let hi = words.length - 1;
-  let idx = -1;
-  while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
-    if (words[mid].start <= t) {
-      idx = mid;
-      lo = mid + 1;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  if (idx >= 0 && t < words[idx].end + 0.15) return words[idx].id;
-  return -1;
-}
 
 const WordSpan = memo(function WordSpan({
   word,
@@ -122,7 +106,6 @@ const SplitMarker = memo(function SplitMarker({
 
 export default function TranscriptPanel() {
   const words = useEditorStore((s) => s.words);
-  const manualCuts = useEditorStore((s) => s.manualCuts);
   const sceneBoundaries = useEditorStore((s) => s.sceneBoundaries);
   const duration = useEditorStore((s) => s.duration);
   const status = useEditorStore((s) => s.status);
@@ -140,10 +123,7 @@ export default function TranscriptPanel() {
   const playing = useEditorStore((s) => s.playing);
   const activeWordId = useEditorStore((s) => findActiveWordId(s.words, s.currentTime));
 
-  const cuts = useMemo(
-    () => getCutRanges(words, duration, manualCuts),
-    [words, duration, manualCuts]
-  );
+  const cuts = useCutRanges();
   const cutOutIds = useMemo(() => {
     const ids = new Set<number>();
     for (const w of words) {
@@ -189,15 +169,7 @@ export default function TranscriptPanel() {
     correctingRef,
   });
 
-  const turns = useMemo<SpeakerTurn[]>(() => {
-    const out: SpeakerTurn[] = [];
-    for (const w of words) {
-      const last = out[out.length - 1];
-      if (last && last.speaker === w.speaker) last.words.push(w);
-      else out.push({ speaker: w.speaker, words: [w] });
-    }
-    return out;
-  }, [words]);
+  const turns = useMemo(() => groupWordsBySpeaker(words), [words]);
 
   const deletedCount = useMemo(() => cutOutIds.size, [cutOutIds]);
   const fillerIds = useMemo(() => findFillerWordIds(words), [words]);
@@ -211,7 +183,7 @@ export default function TranscriptPanel() {
       const file = files?.[0];
       if (!file) return;
       if (!isTranscriptFile(file)) {
-        alert("Please choose an SRT, VTT, or JSON transcript.");
+        alert(TRANSCRIPT_FILE_ERROR);
         return;
       }
       if (
@@ -229,13 +201,6 @@ export default function TranscriptPanel() {
       }
     },
     [words.length, importWords]
-  );
-
-  const joinSplit = useCallback(
-    (id: number) => {
-      removeSceneBoundary(id);
-    },
-    [removeSceneBoundary]
   );
 
   const cutSelection = useCallback(() => {
@@ -438,7 +403,7 @@ export default function TranscriptPanel() {
                         return (
                           <React.Fragment key={w.id}>
                             {split && (
-                              <SplitMarker boundaryId={split.id} onJoin={joinSplit} />
+                              <SplitMarker boundaryId={split.id} onJoin={removeSceneBoundary} />
                             )}
                             <WordSpan
                               word={w}

--- a/components/TranscriptScrollIndicator.tsx
+++ b/components/TranscriptScrollIndicator.tsx
@@ -18,7 +18,7 @@ const MIN_THUMB_H = 28;
 /** Kept in sync with the label's `h-3.5` so it can be centred on the thumb. */
 const LABEL_H = 14;
 /** Candidate spacings between ticks, in seconds, coarsest last. */
-const TICK_STEPS = [5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600];
+const SCROLL_RAIL_TICK_STEPS_S = [5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600];
 const MIN_TICK_GAP = 13;
 /** Timestamps land wherever the text puts them, so the gaps between them are
  *  filled with plain ruler ticks at roughly this pitch. */
@@ -276,8 +276,8 @@ export default function TranscriptScrollIndicator({
     const { railH, travel } = geometry;
     const spanned = last - first;
     const step =
-      TICK_STEPS.find((s) => (s / spanned) * travel >= MIN_TICK_GAP) ??
-      TICK_STEPS[TICK_STEPS.length - 1];
+      SCROLL_RAIL_TICK_STEPS_S.find((s) => (s / spanned) * travel >= MIN_TICK_GAP) ??
+      SCROLL_RAIL_TICK_STEPS_S[SCROLL_RAIL_TICK_STEPS_S.length - 1];
     const next: Tick[] = [];
     for (let t = Math.ceil(first / step) * step; t <= last; t += step) {
       const y = railY(topAt(measured, t), geometry);

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -29,6 +29,7 @@ import {
   listProjects,
   type ProjectMeta,
 } from "@/lib/projects";
+import { isElectron } from "@/lib/platform";
 import { useEditorStore } from "@/lib/store";
 import type { Word } from "@/lib/types";
 
@@ -154,7 +155,6 @@ export default function UploadScreen({
 }: {
   onFile: (file: File, options?: { words?: Word[] }) => void;
 }) {
-  const isElectron = /electron/i.test(navigator.userAgent);
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
   const [projects, setProjects] = useState<ProjectMeta[]>([]);

--- a/hooks/useCutRanges.ts
+++ b/hooks/useCutRanges.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useMemo } from "react";
+import { getCutRanges } from "@/lib/edits";
+import { useEditorStore } from "@/lib/store";
+
+export function useCutRanges() {
+  const words = useEditorStore((s) => s.words);
+  const manualCuts = useEditorStore((s) => s.manualCuts);
+  const duration = useEditorStore((s) => s.duration);
+  return useMemo(
+    () => getCutRanges(words, duration, manualCuts),
+    [words, duration, manualCuts]
+  );
+}

--- a/hooks/useTranscriptSelection.ts
+++ b/hooks/useTranscriptSelection.ts
@@ -7,6 +7,7 @@ import {
   useState,
   type RefObject,
 } from "react";
+import { PLAYHEAD_EPSILON_S } from "@/lib/edits";
 import { useEditorStore } from "@/lib/store";
 import type { Word } from "@/lib/types";
 
@@ -186,9 +187,7 @@ export function useTranscriptSelection({
   }, []);
 
   const seekToWord = useCallback((word: Word) => {
-    const { videoEl, setCurrentTime } = useEditorStore.getState();
-    if (videoEl) videoEl.currentTime = word.start + 0.001;
-    setCurrentTime(word.start + 0.001);
+    useEditorStore.getState().seekTo(word.start + PLAYHEAD_EPSILON_S);
   }, []);
 
   const handleWordClick = useCallback(

--- a/lib/edits.ts
+++ b/lib/edits.ts
@@ -14,6 +14,8 @@ export const MIN_CLIP_DURATION = 0.05;
 
 /** Ignore splits this close to an existing edge (seconds). */
 export const SPLIT_EPSILON = 0.04;
+/** Tiny seek offset so playhead lands just inside a kept region. */
+export const PLAYHEAD_EPSILON_S = 0.001;
 
 /**
  * Compute cut ranges from deleted words only (silence between adjacent deleted

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -32,9 +32,6 @@ export interface ModelInfo {
 /** Display order for Whisper rows in the homepage source dropdown. */
 export const WHISPER_ORDER: WhisperModel[] = ["base", "small"];
 
-/** @deprecated Prefer WHISPER_ORDER; kept for older imports. */
-export const MODEL_ORDER = WHISPER_ORDER;
-
 const WHISPER_DTYPE = {
   // q4 decoder: q8 fails session creation on onnxruntime-web 1.26
   // (Missing required scale … MatMulNBits).

--- a/lib/parseTranscript.ts
+++ b/lib/parseTranscript.ts
@@ -3,6 +3,7 @@ import type { Word } from "./types";
 /** Caption / transcript files we can turn into timed words. */
 export const TRANSCRIPT_ACCEPT =
   ".srt,.vtt,.json,application/json,text/vtt,text/plain";
+export const TRANSCRIPT_FILE_ERROR = "Choose an SRT, VTT, or JSON file.";
 
 const TRANSCRIPT_EXT = /\.(srt|vtt|json)$/i;
 

--- a/lib/platform.ts
+++ b/lib/platform.ts
@@ -1,0 +1,2 @@
+export const isElectron =
+  typeof navigator !== "undefined" && /electron/i.test(navigator.userAgent);

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -17,6 +17,7 @@ import {
   getClipSegments,
   getCutRanges,
   getKeepRanges,
+  PLAYHEAD_EPSILON_S,
   shrinkManualCuts,
   trimEdgeResult,
 } from "./edits";
@@ -32,7 +33,6 @@ import {
   deleteProject,
   fileFromProject,
   getProject,
-  type ProjectMeta,
 } from "./projects";
 
 interface PendingTranscript {
@@ -151,6 +151,7 @@ interface EditorState {
   redo: () => void;
   toggleShowDeleted: () => void;
   setCurrentTime: (t: number) => void;
+  seekTo: (t: number) => void;
   setPlaying: (p: boolean) => void;
   setVideoEl: (el: HTMLMediaElement | null) => void;
   /** Play/pause, skipping out of cut ranges and restarting from the start if parked at the end. */
@@ -635,6 +636,11 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   },
 
   setCurrentTime: (currentTime) => set({ currentTime }),
+  seekTo: (time) => {
+    const media = get().videoEl;
+    if (media) media.currentTime = time;
+    set({ currentTime: time });
+  },
   setPlaying: (playing) => set({ playing }),
   setVideoEl: (videoEl) => set({ videoEl }),
   togglePlayback: () => {
@@ -644,7 +650,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     if (media.paused) {
       const cuts = getCutRanges(s.words, s.duration, s.manualCuts);
       const cut = cutRangeAt(media.currentTime, cuts);
-      if (cut) media.currentTime = cut.end + 0.001;
+      if (cut) media.currentTime = cut.end + PLAYHEAD_EPSILON_S;
       if (media.currentTime >= media.duration - 0.05) media.currentTime = 0;
       void media.play();
     } else {
@@ -697,5 +703,3 @@ export function hydrateModelPreference() {
     useEditorStore.setState({ model: stored });
   }
 }
-
-export type { ProjectMeta };

--- a/lib/transcript.ts
+++ b/lib/transcript.ts
@@ -1,0 +1,28 @@
+import type { SpeakerTurn, Word } from "./types";
+
+export function findActiveWordId(words: Word[], timeS: number): number {
+  let lo = 0;
+  let hi = words.length - 1;
+  let idx = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (words[mid].start <= timeS) {
+      idx = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  if (idx >= 0 && timeS < words[idx].end + 0.15) return words[idx].id;
+  return -1;
+}
+
+export function groupWordsBySpeaker(words: Word[]): SpeakerTurn[] {
+  const turns: SpeakerTurn[] = [];
+  for (const word of words) {
+    const last = turns[turns.length - 1];
+    if (last && last.speaker === word.speaker) last.words.push(word);
+    else turns.push({ speaker: word.speaker, words: [word] });
+  }
+  return turns;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR applies low-risk readability cleanups focused on recently modified editor areas.

### Dead code and wrapper cleanup
- Removed 8 unused `lucide-react` imports in `components/Timeline.tsx`.
- Removed the no-op `doSplit` wrapper in `components/Timeline.tsx`.
- Removed the `joinSplit` passthrough callback in `components/TranscriptPanel.tsx` and passed `removeSceneBoundary` directly.
- Removed unused `MODEL_ORDER` export from `lib/models.ts`.
- Removed unused `ProjectMeta` re-export (and import) from `lib/store.ts`.
- Made `SPEAKER_COLORS` and `speakerColor` module-private in `components/TranscriptPanel.tsx`.

### Naming and constant clarity
- Added `PLAYHEAD_EPSILON_S` in `lib/edits.ts` and replaced duplicated `0.001` literals.
- Renamed transcript scroll rail tick constant to `SCROLL_RAIL_TICK_STEPS_S` in `components/TranscriptScrollIndicator.tsx`.
- Reused canonical `VAD_SAMPLE_RATE` in `components/Timeline.tsx` and `components/Editor.tsx`.

### Shared helper extraction
- Added `hooks/useCutRanges.ts` and replaced repeated `getCutRanges` `useMemo` blocks in:
  - `components/Timeline.tsx`
  - `components/TranscriptPanel.tsx`
  - `components/ExportDialog.tsx`
  - `components/MediaPreview.tsx`
- Added `seekTo` action to `lib/store.ts` and switched duplicated seek logic to use it from:
  - `components/Timeline.tsx`
  - `hooks/useTranscriptSelection.ts`

### Transcript/platform helper extraction
- Added `lib/transcript.ts` with:
  - `findActiveWordId`
  - `groupWordsBySpeaker`
- Added `lib/platform.ts` with shared `isElectron` detection.
- Replaced duplicated `isElectron` user-agent checks in:
  - `app/layout.tsx`
  - `components/Editor.tsx`
  - `components/UploadScreen.tsx`

### Shared transcript file validation message
- Added `TRANSCRIPT_FILE_ERROR` in `lib/parseTranscript.ts`.
- Reused it in:
  - `components/ImportTranscriptOption.tsx`
  - `components/TranscriptPanel.tsx`

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

All passed locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b499cbec-eb0c-414e-8f64-158f53be823e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b499cbec-eb0c-414e-8f64-158f53be823e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

