### PR TITLE
Add one-click silence removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ builds auto-update from GitHub Releases. Prefer the browser? Use the
 - 📝 **Word-level editing** — select words, press ⌫, the cut follows the text
 - 📥 **Import your own transcript** — skip Whisper and edit with an SRT, VTT, or JSON caption file
 - 🧹 **Filler removal** — one-click cut of "um", "uh", and similar fillers
+- 🔇 **Silence removal** — one-click cut of pauses and dead air (≥0.3s)
 - 🗣️ **Speaker diarization** — the transcript is grouped by speaker
 - 🎬 **Timeline** — waveform, wordbar with draggable timing handles, Split,
   cut regions, playhead; scroll to zoom, side-scroll to pan
@@ -91,6 +92,7 @@ audio track. For desktop packaging, signing, and cutting releases, see
 3. **Edit** — deleting words produces "cut ranges" of the original media. The
    preview player skips them in real time and the timeline shows them in red.
    **Remove fillers** cuts every detected "um" / "uh" / etc. in one click.
+   **Remove silences** cuts pauses and dead air of 0.3s or longer.
 4. **Export** — the kept ranges are trimmed and concatenated with an ffmpeg
    filter graph and re-encoded (`libx264`/`aac`), so cuts are word-accurate.
 

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -11,11 +11,13 @@ import {
   RotateCcw,
   Scissors,
   VolumeOff,
+  VolumeX,
   WandSparkles,
   X,
 } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import { findFillerWordIds } from "@/lib/fillers";
+import { findSilenceRanges } from "@/lib/silences";
 import {
   isTranscriptFile,
   parseTranscriptFile,
@@ -118,8 +120,10 @@ export default function TranscriptPanel() {
   const toggleShowDeleted = useEditorStore((s) => s.toggleShowDeleted);
   const deleteWords = useEditorStore((s) => s.deleteWords);
   const restoreWords = useEditorStore((s) => s.restoreWords);
+  const cutRanges = useEditorStore((s) => s.cutRanges);
   const correctWords = useEditorStore((s) => s.correctWords);
   const importWords = useEditorStore((s) => s.importWords);
+  const manualCuts = useEditorStore((s) => s.manualCuts);
   const removeSceneBoundary = useEditorStore((s) => s.removeSceneBoundary);
   const selectedWordIds = useEditorStore((s) => s.selectedWordIds);
   const playing = useEditorStore((s) => s.playing);
@@ -175,10 +179,18 @@ export default function TranscriptPanel() {
 
   const deletedCount = useMemo(() => cutOutIds.size, [cutOutIds]);
   const fillerIds = useMemo(() => findFillerWordIds(words), [words]);
+  const silenceRanges = useMemo(
+    () => findSilenceRanges(words, duration, manualCuts),
+    [words, duration, manualCuts]
+  );
 
   const removeFillers = useCallback(() => {
     deleteWords(fillerIds);
   }, [deleteWords, fillerIds]);
+
+  const removeSilences = useCallback(() => {
+    cutRanges(silenceRanges);
+  }, [cutRanges, silenceRanges]);
 
   const handleImportTranscript = useCallback(
     async (files: FileList | null) => {
@@ -308,6 +320,16 @@ export default function TranscriptPanel() {
             >
               <WandSparkles size={14} />
               <span className="hidden sm:inline">Remove filler words ({fillerIds.length})</span>
+            </button>
+          )}
+          {status === "ready" && silenceRanges.length > 0 && (
+            <button
+              onClick={removeSilences}
+              title="Cut pauses and silences (≥0.3s) from the video"
+              className="flex cursor-pointer h-7 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-500 transition hover:bg-zinc-100 line-clamp-1 dark:text-zinc-400 dark:hover:bg-zinc-800"
+            >
+              <VolumeX size={14} />
+              <span className="hidden sm:inline">Remove silences ({silenceRanges.length})</span>
             </button>
           )}
           {(status === "ready" || status === "error" || status === "transcribing") && (

--- a/lib/silences.ts
+++ b/lib/silences.ts
@@ -1,0 +1,95 @@
+import { getCutRanges, isWordCutOut } from "./edits";
+import type { ManualCut, TimeRange, Word } from "./types";
+
+/**
+ * Minimum gap length (seconds) that counts as a removable silence.
+ * Shorter gaps are normal inter-word spacing from ASR and should stay.
+ */
+export const MIN_SILENCE_DURATION = 0.3;
+
+/**
+ * Leave this much audio (seconds) beside kept speech so word onsets/offsets
+ * aren't clipped when Whisper timestamps are slightly tight.
+ */
+export const SILENCE_PAD = 0.05;
+
+/** Split `range` into the pieces not covered by any of `cuts`. */
+function subtractCuts(range: TimeRange, cuts: TimeRange[]): TimeRange[] {
+  let parts: TimeRange[] = [range];
+  for (const cut of cuts) {
+    parts = parts.flatMap((p) => {
+      if (cut.end <= p.start + 1e-4 || cut.start >= p.end - 1e-4) return [p];
+      const out: TimeRange[] = [];
+      if (cut.start > p.start + 1e-4) out.push({ start: p.start, end: cut.start });
+      if (cut.end < p.end - 1e-4) out.push({ start: cut.end, end: p.end });
+      return out;
+    });
+  }
+  return parts;
+}
+
+/**
+ * Find silence ranges in the media that are not already cut: gaps before the
+ * first kept word, between kept words, and after the last kept word, each at
+ * least `minDuration` long. A small pad is left beside speech so it isn't
+ * clipped; media edges are cut flush.
+ */
+export function findSilenceRanges(
+  words: Word[],
+  duration: number,
+  manualCuts: ManualCut[] = [],
+  minDuration = MIN_SILENCE_DURATION,
+  pad = SILENCE_PAD
+): TimeRange[] {
+  if (duration <= 0) return [];
+
+  const cuts = getCutRanges(words, duration, manualCuts);
+  const kept = words
+    .filter((w) => !isWordCutOut(w, cuts))
+    .slice()
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+
+  // Raw gaps (no pad yet), tagged with whether each edge abuts speech.
+  type Gap = { start: number; end: number; padStart: boolean; padEnd: boolean };
+  const gaps: Gap[] = [];
+  let cursor = 0;
+  let prevWasSpeech = false;
+  for (const w of kept) {
+    if (w.start > cursor + 1e-4) {
+      gaps.push({
+        start: cursor,
+        end: w.start,
+        padStart: prevWasSpeech,
+        padEnd: true,
+      });
+    }
+    cursor = Math.max(cursor, w.end);
+    prevWasSpeech = true;
+  }
+  if (duration > cursor + 1e-4) {
+    gaps.push({
+      start: cursor,
+      end: duration,
+      padStart: prevWasSpeech,
+      padEnd: false,
+    });
+  }
+
+  const out: TimeRange[] = [];
+  for (const gap of gaps) {
+    if (gap.end - gap.start < minDuration - 1e-4) continue;
+    for (const part of subtractCuts(
+      { start: gap.start, end: gap.end },
+      cuts
+    )) {
+      if (part.end - part.start < minDuration - 1e-4) continue;
+      // Only pad edges that still sit against speech (not against a prior cut).
+      const padStart = gap.padStart && Math.abs(part.start - gap.start) < 1e-4;
+      const padEnd = gap.padEnd && Math.abs(part.end - gap.end) < 1e-4;
+      const start = part.start + (padStart ? pad : 0);
+      const end = part.end - (padEnd ? pad : 0);
+      if (end - start > 1e-4) out.push({ start, end });
+    }
+  }
+  return out;
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,13 +7,16 @@ import type {
   ManualCut,
   ProgressInfo,
   SceneBoundary,
+  TimeRange,
   Word,
 } from "./types";
 import {
+  addManualCut,
   applyWordBounds,
   canSplitAt,
   carrySceneBoundaries,
   cutRangeAt,
+  deleteWordsCoveredBy,
   getClipSegments,
   getCutRanges,
   getKeepRanges,
@@ -135,6 +138,8 @@ interface EditorState {
   importWords: (words: Word[]) => void;
   deleteWords: (ids: number[]) => void;
   restoreWords: (ids: number[]) => void;
+  /** Cut arbitrary time ranges (e.g. detected silences) as manual cuts. */
+  cutRanges: (ranges: TimeRange[]) => void;
   /** Replace the selected (contiguous) words with corrected text. */
   correctWords: (ids: number[], text: string) => void;
   /** Nudge a word's start/end on the timeline (may steal time from neighbors). */
@@ -435,6 +440,21 @@ export const useEditorStore = create<EditorState>((set, get) => ({
         idSet.has(w.id) && !w.deleted ? { ...w, deleted: true } : w
       ),
     });
+  },
+  cutRanges: (ranges) => {
+    const usable = ranges.filter((r) => r.end - r.start > 1e-4);
+    if (usable.length === 0) return;
+    const s = get();
+    let words = s.words;
+    let manualCuts = s.manualCuts;
+    let nextManualCutId = s.nextManualCutId;
+    for (const r of usable) {
+      const added = addManualCut(manualCuts, r.start, r.end, nextManualCutId);
+      manualCuts = added.cuts;
+      nextManualCutId = added.nextId;
+      words = deleteWordsCoveredBy(words, r.start, r.end);
+    }
+    pushEdit(get, set, { words, manualCuts, nextManualCutId });
   },
   restoreWords: (ids) => {
     if (ids.length === 0) return;

--- a/tests/silences-test.ts
+++ b/tests/silences-test.ts
@@ -1,0 +1,112 @@
+import {
+  findSilenceRanges,
+  MIN_SILENCE_DURATION,
+  SILENCE_PAD,
+} from "../lib/silences";
+import type { ManualCut, Word } from "../lib/types";
+
+function nearly(a: number, b: number, eps = 1e-4): boolean {
+  return Math.abs(a - b) < eps;
+}
+
+function w(
+  id: number,
+  start: number,
+  end: number,
+  deleted = false
+): Word {
+  return { id, text: `w${id}`, start, end, speaker: 0, deleted };
+}
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+{
+  // Leading + inter-word + trailing silences above the threshold.
+  const words = [w(1, 1.0, 1.5), w(2, 3.0, 3.5)];
+  const ranges = findSilenceRanges(words, 5.0);
+  assert(ranges.length === 3, `expected 3 silences, got ${ranges.length}`);
+  // Leading: flush start, pad before speech.
+  assert(nearly(ranges[0]!.start, 0) && nearly(ranges[0]!.end, 1.0 - SILENCE_PAD), "leading");
+  // Between words: pad both sides.
+  assert(
+    nearly(ranges[1]!.start, 1.5 + SILENCE_PAD) &&
+      nearly(ranges[1]!.end, 3.0 - SILENCE_PAD),
+    "between"
+  );
+  // Trailing: pad after speech, flush end.
+  assert(
+    nearly(ranges[2]!.start, 3.5 + SILENCE_PAD) && nearly(ranges[2]!.end, 5.0),
+    "trailing"
+  );
+  console.log("leading/between/trailing: ok");
+}
+
+{
+  // Tiny inter-word gaps must not count as silence.
+  const words = [w(1, 0.5, 1.0), w(2, 1.05, 1.5)];
+  const ranges = findSilenceRanges(words, 1.5);
+  assert(ranges.length === 1, "only leading silence");
+  assert(nearly(ranges[0]!.end, 0.5 - SILENCE_PAD), "leading only");
+  console.log("short gaps ignored: ok");
+}
+
+{
+  // Exactly at the threshold (before pad) should be detected.
+  const gap = MIN_SILENCE_DURATION;
+  const words = [w(1, 0, 1), w(2, 1 + gap, 2)];
+  const ranges = findSilenceRanges(words, 2);
+  assert(ranges.length === 1, "threshold silence detected");
+  assert(
+    nearly(ranges[0]!.start, 1 + SILENCE_PAD) &&
+      nearly(ranges[0]!.end, 1 + gap - SILENCE_PAD),
+    "padded threshold cut"
+  );
+  console.log("threshold silence: ok");
+}
+
+{
+  // Deleted words already cut their span; silence around them is still found,
+  // and the already-cut middle is not re-reported.
+  const words = [w(1, 0.5, 1.0), w(2, 1.5, 2.0, true), w(3, 3.0, 3.5)];
+  const ranges = findSilenceRanges(words, 3.5);
+  // Gap 1.0→3.0 minus deleted cut 1.5–2.0 → [1.0,1.5] and [2.0,3.0], each padded.
+  assert(ranges.length === 3, `expected leading + 2 remnants, got ${ranges.length}`);
+  assert(nearly(ranges[0]!.start, 0) && nearly(ranges[0]!.end, 0.5 - SILENCE_PAD), "leading");
+  assert(
+    nearly(ranges[1]!.start, 1.0 + SILENCE_PAD) && nearly(ranges[1]!.end, 1.5),
+    "before deleted word (flush against existing cut)"
+  );
+  assert(
+    nearly(ranges[2]!.start, 2.0) && nearly(ranges[2]!.end, 3.0 - SILENCE_PAD),
+    "after deleted word"
+  );
+  console.log("around deleted words: ok");
+}
+
+{
+  // Already-manual-cut silences disappear from the list (button can hide).
+  const words = [w(1, 1.0, 1.5), w(2, 3.0, 3.5)];
+  const manual: ManualCut[] = [{ id: 1, start: 0, end: 1.0 - SILENCE_PAD }];
+  const ranges = findSilenceRanges(words, 5.0, manual);
+  assert(ranges.length === 2, `leading already cut; got ${ranges.length}`);
+  assert(ranges.every((r) => r.start >= 1.0), "no leading remnant");
+  console.log("skips existing manual cuts: ok");
+}
+
+{
+  // Idempotent: after cutting all detected silences, none remain.
+  const words = [w(1, 1.0, 1.5), w(2, 3.0, 3.5)];
+  const first = findSilenceRanges(words, 5.0);
+  const manual: ManualCut[] = first.map((r, i) => ({
+    id: i + 1,
+    start: r.start,
+    end: r.end,
+  }));
+  const second = findSilenceRanges(words, 5.0, manual);
+  assert(second.length === 0, `expected no remaining silences, got ${second.length}`);
+  console.log("idempotent after cut: ok");
+}
+
+console.log("ALL SILENCE TESTS PASSED");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Remove silences (N)** button next to the existing filler-removal control in the transcript header. One click cuts pauses and dead air of 0.3s or longer from the video.

## Behavior

- Detection lives in `lib/silences.ts`: gaps before the first kept word, between kept words, and after the last kept word are treated as silence when they are at least **0.3s**. Shorter ASR inter-word spacing is left alone.
- A small pad (0.05s) is kept beside speech so word onsets/offsets aren’t clipped; media edges are cut flush.
- Already-cut regions (deleted words or prior manual cuts) are excluded, so the button’s count drops to zero after use and the action is idempotent.
- Removal goes through a new `cutRanges` store action that adds manual cuts (same path as blade/trim), so silence cuts show on the timeline, skip in preview/export, and support undo/redo.

## Testing

- Unit tests in `tests/silences-test.ts` cover leading/between/trailing gaps, short-gap filtering, threshold behavior, interaction with deleted words, skipping existing manual cuts, and idempotency after cutting.
- `npm run lint` and `tsc --noEmit` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bd24fdd-b4ff-4ba1-914d-2de0271630ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bd24fdd-b4ff-4ba1-914d-2de0271630ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

