### PR TITLE
Add ROADMAP.md with shipped features marked done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,87 @@
+# Roadmap
+
+User-facing progress for Rescript. Items are marked done when they shipped to
+`main` (web and/or desktop). Internal refactors and CI-only work are omitted.
+
+## Done
+
+### Core editor
+- [x] Offline transcript-based editor in the browser (no server, no auth, no uploads)
+- [x] Upload → local Whisper transcription with per-word timestamps
+- [x] Speaker diarization (pyannote) with speaker-grouped transcript
+- [x] Cut / restore by selecting words (⌫, floating toolbar); undo / redo
+- [x] Live preview that skips cut ranges in real time
+- [x] Timeline with waveform, ruler, word labels, cut regions, playhead, and zoom
+- [x] In-browser export to MP4 (ffmpeg.wasm, word-accurate cuts)
+- [x] Continuous selection highlight and Descript-style timeline word pills
+- [x] Cache-aware model loading labels; speaker model preloaded during transcription
+- [x] Monotonic download / transcription progress
+
+### Editing & transcript tools
+- [x] Correct misrecognized words (selection → Correct popover; timings redistributed)
+- [x] One-click **Remove fillers** (um / uh / etc.)
+- [x] One-click **Remove silences** (pauses / dead air ≥ 0.3s)
+- [x] Import your own transcript (SRT / VTT / JSON) instead of running Whisper
+- [x] Import cancel UX (no stuck selector / blocked media drop)
+
+### Transcription quality & models
+- [x] Whisper Base and Whisper Small selectable on upload
+- [x] Silence skip (VAD) and hallucination mitigations for longer files
+- [x] Multi-speaker clips no longer drop the second speaker after silence-skip
+- [x] Smoother transcription progress across Whisper windows
+- [x] Better word↔audio alignment (speech-onset anchoring / lag correction)
+- [x] Multilingual transcription (language selector; English + German, with DE fillers)
+- [x] WebGPU → WASM fallback when the GPU is lost (e.g. Windows screen lock)
+- [x] Graceful handling of media with no audio track
+
+### Audio & media kinds
+- [x] Edit audio files (mp3 / wav / m4a / …) the same way as video
+- [x] Audio-only workspace (hide empty video preview; transcript gets full width)
+- [x] Audio export (M4A and additional formats via the export dialog)
+
+### Timeline editing (Descript-style)
+- [x] Drag word start / end to fix ASR bleed
+- [x] Split at playhead (`S` / Split) into selectable clips
+- [x] Clip trim handles (manual cuts; covered words marked cut in the transcript)
+- [x] Draggable cut edges; scrub while dragging; double-click to reset
+- [x] Scroll to zoom / side-scroll to pan
+- [x] Timeline ↔ transcript selection sync; splits reflected in the transcript
+- [x] Word chips visible at all zoom levels
+- [x] Waveform peak clamping on the timeline
+
+### Layout, mobile & chrome
+- [x] Mobile-friendly stacked editor layout
+- [x] Upload screen scrollable on short / mobile viewports
+- [x] Resizable transcript / preview split on desktop (persisted)
+- [x] Transcript scroll rail with tick marks and edge fades
+- [x] Light / Dark appearance in Settings (persisted; default light)
+- [x] Settings menu (appearance + community / support links)
+- [x] Social links (Discord, X, GitHub)
+- [x] Mobile menus stay on-screen (Floating UI flip / shift)
+- [x] Smoother transcript text selection while dragging
+- [x] Spacebar play / pause reliability and media-control polish
+
+### Projects & persistence
+- [x] Auto-save projects to IndexedDB
+- [x] Recent projects list on the home screen (open / delete)
+
+### Export
+- [x] Tabbed export dialog: **Video**, **Audio**, **Transcript**, **Subtitles**
+- [x] Video: format (MP4 / WebM) and resolution options
+- [x] Audio: M4A / MP3 / WAV (including from video projects)
+- [x] Transcript: plain text or Markdown (speaker turns, cuts removed)
+- [x] Subtitles: SRT / VTT (edited timeline) or JSON (full words for re-import)
+
+### Desktop & distribution
+- [x] Live web app on GitHub Pages
+- [x] Electron desktop app for macOS, Windows, and Linux
+- [x] Signed / notarized Mac builds; auto-update from GitHub Releases
+- [x] Desktop chrome polish (traffic lights, window sizing, animated logo / top bar)
+
+## Next
+
+- [ ] Native macOS SpeechAnalyzer as an optional transcription backend
+- [ ] More languages beyond English / German; local model import for air-gapped first runs
+- [ ] Faster export (stream-copy for keyframe-aligned segments, WebCodecs rendering)
+- [ ] Multi-clip projects (reorder scenes), captions burn-in
+- [ ] Gap clips / insert silence between words

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,11 @@ User-facing progress for Rescript. Items are marked done when they shipped to
 
 ## Next
 
+- [ ] **Parakeet TDT v3** as an optional transcription backend (faster / more accurate word timings)
+- [ ] Fix remaining drift / lag and push word timestamps closer to true speech boundaries
+- [ ] In-app transcript editor (richer inline editing beyond the Correct popover)
+- [ ] Export the timeline itself to video editing tools (e.g. project / EDL / FCPXML-style interchange)
+- [ ] **Regenerate** — text-to-speech with accurate voice cloning so rewritten lines can be spoken in the original voice
 - [ ] Native macOS SpeechAnalyzer as an optional transcription backend
 - [ ] More languages beyond English / German; local model import for air-gapped first runs
 - [ ] Faster export (stream-copy for keyframe-aligned segments, WebCodecs rendering)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `ROADMAP.md` listing user-facing work shipped so far (core editor through timeline editing, desktop app, dark mode, tabbed export, silence removal, languages, etc.) as checked-off items.

**Next** includes planned work:
- Parakeet TDT v3 transcription
- Tighter drift/lag / word timestamp accuracy
- In-app transcript editor
- Timeline export to video editing tools
- Regenerate (TTS with accurate voice cloning)
- Plus remaining ideas carried over from `PLAN.md`

Internal refactors and CI-only work are omitted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb4e3-5650-7eed-84b7-67ae19c89f8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb4e3-5650-7eed-84b7-67ae19c89f8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

