### PR TITLE
Timeline clip delete and cut/silence restore

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { useEditorStore } from "@/lib/store";
+import { getCutRanges, isWordCutOut } from "@/lib/edits";
 import { extractAudio, getFFmpeg } from "@/lib/ffmpeg";
 import { VAD_SAMPLE_RATE } from "@/lib/vad";
 import { isElectron } from "@/lib/platform";
@@ -176,7 +177,8 @@ export default function Editor() {
     return () => window.clearTimeout(timer);
   }, [status]);
 
-  // Global shortcuts: space = play/pause, ⌘Z / ⇧⌘Z = undo / redo, S = split.
+  // Global shortcuts: space = play/pause, ⌘Z / ⇧⌘Z = undo / redo, S = split,
+  // Delete/Backspace = delete selected clip or restore selected cut / cut words.
   // Capture phase so Space is ours before a focused <button> synthesizes a click
   // (which would double-toggle playback and look like the hotkey "didn't work").
   useEffect(() => {
@@ -203,6 +205,40 @@ export default function Editor() {
       ) {
         e.preventDefault();
         s.splitAtPlayhead();
+      } else if (
+        (e.key === "Delete" || e.key === "Backspace") &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        s.status === "ready" &&
+        !s.exportOpen
+      ) {
+        // Cut region selected → restore it (also covers cut words clicked on
+        // the timeline, which select their cut). Kept words → cut them. Clip
+        // selected with no words → delete the clip.
+        if (s.selectedCutIndex != null) {
+          e.preventDefault();
+          e.stopPropagation();
+          s.restoreSelectedCut();
+          return;
+        }
+        if (s.selectedWordIds.length > 0) {
+          e.preventDefault();
+          e.stopPropagation();
+          const cuts = getCutRanges(s.words, s.duration, s.manualCuts);
+          const selected = s.words.filter((w) => s.selectedWordIds.includes(w.id));
+          const allCutOut =
+            selected.length > 0 && selected.every((w) => isWordCutOut(w, cuts));
+          if (allCutOut) s.restoreWords(s.selectedWordIds);
+          else s.deleteWords(s.selectedWordIds);
+          s.setSelectedWords([]);
+          return;
+        }
+        if (s.selectedClipIndex != null) {
+          e.preventDefault();
+          e.stopPropagation();
+          s.deleteSelectedClip();
+        }
       }
     };
     document.addEventListener("keydown", handler, true);

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -55,6 +55,32 @@ const MAX_ZOOM = 256;
 const ZOOM_SPEED = 0.0028;
 /** How close (px) the pointer must be to a split marker to reveal its join button. */
 const SPLIT_HOVER_PX = 10;
+/** Inset + radius for selected clip/cut outlines (`rounded-sm` ≈ 2px). */
+const SELECTION_INSET = 2;
+const SELECTION_RADIUS = 2;
+
+/** Canvas path for a rounded rect (used to keep cut fills inside the selection ring). */
+function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number
+) {
+  const radius = Math.max(0, Math.min(r, w / 2, h / 2));
+  ctx.beginPath();
+  if (radius <= 0 || w <= 0 || h <= 0) {
+    ctx.rect(x, y, Math.max(0, w), Math.max(0, h));
+    return;
+  }
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+}
 
 type DragKind =
   | { type: "seek" }
@@ -221,7 +247,16 @@ export default function Timeline() {
       const hovered = clip.index === hoveredClipIndex && !selected;
       if (selected) {
         ctx.fillStyle = dark ? "rgba(99, 102, 241, 0.20)" : "rgba(99, 102, 241, 0.10)";
-        ctx.fillRect(x0, trackTop, x1 - x0, trackH);
+        // Inset + round to sit inside the selection ring (same as cuts).
+        roundRectPath(
+          ctx,
+          x0 + SELECTION_INSET,
+          trackTop + SELECTION_INSET,
+          x1 - x0 - SELECTION_INSET * 2,
+          trackH - SELECTION_INSET * 2,
+          SELECTION_RADIUS
+        );
+        ctx.fill();
       } else if (hovered) {
         ctx.fillStyle = dark ? "rgba(99, 102, 241, 0.10)" : "rgba(99, 102, 241, 0.05)";
         ctx.fillRect(x0, trackTop, x1 - x0, trackH);
@@ -235,6 +270,12 @@ export default function Timeline() {
       if (x1 < 0 || x0 > width) return;
       const selected = cutIndex === selectedCutIndex;
       const hovered = cutIndex === hoveredCutIndex && !selected;
+      const fillX = selected ? x0 + SELECTION_INSET : x0;
+      const fillY = selected ? trackTop + SELECTION_INSET : trackTop;
+      const fillW = selected
+        ? x1 - x0 - SELECTION_INSET * 2
+        : x1 - x0;
+      const fillH = selected ? trackH - SELECTION_INSET * 2 : trackH;
       ctx.fillStyle = selected
         ? dark
           ? "rgba(185, 28, 28, 0.62)"
@@ -246,11 +287,20 @@ export default function Timeline() {
           : dark
             ? "rgba(127, 29, 29, 0.45)"
             : "rgba(254, 226, 226, 0.78)";
-      ctx.fillRect(x0, trackTop, x1 - x0, trackH);
-      // subtle hatch
+      if (selected) {
+        roundRectPath(ctx, fillX, fillY, fillW, fillH, SELECTION_RADIUS);
+        ctx.fill();
+      } else {
+        ctx.fillRect(fillX, fillY, fillW, fillH);
+      }
+      // subtle hatch — clipped to the same (rounded) shape as the fill
       ctx.save();
-      ctx.beginPath();
-      ctx.rect(x0, trackTop, x1 - x0, trackH);
+      if (selected) {
+        roundRectPath(ctx, fillX, fillY, fillW, fillH, SELECTION_RADIUS);
+      } else {
+        ctx.beginPath();
+        ctx.rect(fillX, fillY, fillW, fillH);
+      }
       ctx.clip();
       ctx.strokeStyle = selected
         ? dark
@@ -260,10 +310,10 @@ export default function Timeline() {
           ? "rgba(248, 113, 113, 0.35)"
           : "rgba(252, 165, 165, 0.45)";
       ctx.lineWidth = 1;
-      for (let x = x0 - trackH; x < x1 + trackH; x += 6) {
+      for (let x = fillX - fillH; x < fillX + fillW + fillH; x += 6) {
         ctx.beginPath();
-        ctx.moveTo(x, trackTop);
-        ctx.lineTo(x + trackH, trackTop + trackH);
+        ctx.moveTo(x, fillY);
+        ctx.lineTo(x + fillH, fillY + fillH);
         ctx.stroke();
       }
       ctx.restore();
@@ -778,18 +828,18 @@ export default function Timeline() {
               );
             })}
 
-            {/* Selected cut/silence outline — same rounded ring as selected clips */}
+            {/* Selected cut/silence outline */}
             {selectedCutIndex != null && cuts[selectedCutIndex] && (
               <div
-                className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-neutral-400/40"
+                className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-red-400/55 dark:ring-red-300/50"
                 style={{
                   left: cuts[selectedCutIndex].start * pps,
                   width: Math.max(
                     2,
                     (cuts[selectedCutIndex].end - cuts[selectedCutIndex].start) * pps
                   ),
-                  top: RULER_H + WORDBAR_H + 2,
-                  bottom: 2,
+                  top: RULER_H + WORDBAR_H + SELECTION_INSET,
+                  bottom: SELECTION_INSET,
                 }}
               />
             )}
@@ -844,12 +894,12 @@ export default function Timeline() {
                   </div>
                   {selected && (
                     <div
-                      className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-neutral-400/40"
+                      className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-indigo-400/55 dark:ring-indigo-300/50"
                       style={{
                         left: clip.start * pps,
                         width: Math.max(2, (clip.end - clip.start) * pps),
-                        top: RULER_H + WORDBAR_H + 2,
-                        bottom: 2,
+                        top: RULER_H + WORDBAR_H + SELECTION_INSET,
+                        bottom: SELECTION_INSET,
                       }}
                     />
                   )}

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -267,11 +267,6 @@ export default function Timeline() {
         ctx.stroke();
       }
       ctx.restore();
-      if (selected) {
-        ctx.strokeStyle = dark ? "rgba(252, 165, 165, 0.7)" : "rgba(239, 68, 68, 0.55)";
-        ctx.lineWidth = 1.5;
-        ctx.strokeRect(x0 + 0.75, trackTop + 0.75, Math.max(0, x1 - x0 - 1.5), trackH - 1.5);
-      }
     });
 
     // Waveform
@@ -782,6 +777,22 @@ export default function Timeline() {
                 </div>
               );
             })}
+
+            {/* Selected cut/silence outline — same rounded ring as selected clips */}
+            {selectedCutIndex != null && cuts[selectedCutIndex] && (
+              <div
+                className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-red-400/50 dark:ring-red-300/40"
+                style={{
+                  left: cuts[selectedCutIndex].start * pps,
+                  width: Math.max(
+                    2,
+                    (cuts[selectedCutIndex].end - cuts[selectedCutIndex].start) * pps
+                  ),
+                  top: RULER_H + WORDBAR_H + 2,
+                  bottom: 2,
+                }}
+              />
+            )}
 
             {/* Clip trim handles (selected or hovered) */}
             {clips.map((clip) => {

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -781,7 +781,7 @@ export default function Timeline() {
             {/* Selected cut/silence outline — same rounded ring as selected clips */}
             {selectedCutIndex != null && cuts[selectedCutIndex] && (
               <div
-                className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-red-400/50 dark:ring-red-300/40"
+                className="pointer-events-none absolute z-[4] rounded-sm ring-1 ring-neutral-400/40"
                 style={{
                   left: cuts[selectedCutIndex].start * pps,
                   width: Math.max(

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -16,13 +16,16 @@ import {
   Merge,
   Pause,
   Play,
+  RotateCcw,
   SquareSplitHorizontal,
+  Trash2,
   ZoomIn,
   ZoomOut,
 } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
 import {
   canSplitAt,
+  cutRangeAt,
   formatTime,
   getActiveSceneBoundaries,
   getClipSegments,
@@ -71,6 +74,7 @@ export default function Timeline() {
   const currentTime = useEditorStore((s) => s.currentTime);
   const playing = useEditorStore((s) => s.playing);
   const selectedClipIndex = useEditorStore((s) => s.selectedClipIndex);
+  const selectedCutIndex = useEditorStore((s) => s.selectedCutIndex);
   const selectedWordIds = useEditorStore((s) => s.selectedWordIds);
   const status = useEditorStore((s) => s.status);
 
@@ -102,6 +106,7 @@ export default function Timeline() {
   const [zoom, setZoom] = useState(1);
   const [hoveredWordId, setHoveredWordId] = useState<number | null>(null);
   const [hoveredClipIndex, setHoveredClipIndex] = useState<number | null>(null);
+  const [hoveredCutIndex, setHoveredCutIndex] = useState<number | null>(null);
   /** Id of the split marker under the pointer, if any. */
   const [hoveredSplitId, setHoveredSplitId] = useState<number | null>(null);
   const dark = useIsDark();
@@ -110,6 +115,23 @@ export default function Timeline() {
   const pps = fitPps * zoom;
   const totalWidth = Math.max(width, duration * pps);
   const ready = status === "ready" && duration > 0;
+  const deleteOk =
+    selectedClipIndex != null &&
+    clips.some((c) => c.index === selectedClipIndex);
+  const selectedWordsAllCutOut = useMemo(() => {
+    if (selectedWordIds.length === 0) return false;
+    const idSet = new Set(selectedWordIds);
+    let count = 0;
+    for (const w of words) {
+      if (!idSet.has(w.id)) continue;
+      count++;
+      if (!isWordCutOut(w, cuts)) return false;
+    }
+    return count > 0;
+  }, [selectedWordIds, words, cuts]);
+  const restoreOk =
+    (selectedCutIndex != null && cuts[selectedCutIndex] != null) ||
+    selectedWordsAllCutOut;
 
   // Live mirrors for imperative wheel/drag handlers (avoid stale closures).
   const ppsRef = useRef(pps);
@@ -203,19 +225,37 @@ export default function Timeline() {
       }
     }
 
-    // Cut range backgrounds
-    for (const cut of cuts) {
+    // Cut range backgrounds (selected / hovered wash stronger)
+    cuts.forEach((cut, cutIndex) => {
       const x0 = cut.start * pps - scrollLeft;
       const x1 = cut.end * pps - scrollLeft;
-      if (x1 < 0 || x0 > width) continue;
-      ctx.fillStyle = dark ? "rgba(127, 29, 29, 0.45)" : "rgba(254, 226, 226, 0.78)";
+      if (x1 < 0 || x0 > width) return;
+      const selected = cutIndex === selectedCutIndex;
+      const hovered = cutIndex === hoveredCutIndex && !selected;
+      ctx.fillStyle = selected
+        ? dark
+          ? "rgba(185, 28, 28, 0.62)"
+          : "rgba(254, 202, 202, 0.95)"
+        : hovered
+          ? dark
+            ? "rgba(153, 27, 27, 0.55)"
+            : "rgba(254, 226, 226, 0.9)"
+          : dark
+            ? "rgba(127, 29, 29, 0.45)"
+            : "rgba(254, 226, 226, 0.78)";
       ctx.fillRect(x0, trackTop, x1 - x0, trackH);
       // subtle hatch
       ctx.save();
       ctx.beginPath();
       ctx.rect(x0, trackTop, x1 - x0, trackH);
       ctx.clip();
-      ctx.strokeStyle = dark ? "rgba(248, 113, 113, 0.35)" : "rgba(252, 165, 165, 0.45)";
+      ctx.strokeStyle = selected
+        ? dark
+          ? "rgba(252, 165, 165, 0.55)"
+          : "rgba(248, 113, 113, 0.65)"
+        : dark
+          ? "rgba(248, 113, 113, 0.35)"
+          : "rgba(252, 165, 165, 0.45)";
       ctx.lineWidth = 1;
       for (let x = x0 - trackH; x < x1 + trackH; x += 6) {
         ctx.beginPath();
@@ -224,7 +264,12 @@ export default function Timeline() {
         ctx.stroke();
       }
       ctx.restore();
-    }
+      if (selected) {
+        ctx.strokeStyle = dark ? "rgba(252, 165, 165, 0.7)" : "rgba(239, 68, 68, 0.55)";
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(x0 + 0.75, trackTop + 0.75, Math.max(0, x1 - x0 - 1.5), trackH - 1.5);
+      }
+    });
 
     // Waveform
     if (!audio) return;
@@ -261,6 +306,8 @@ export default function Timeline() {
     height,
     selectedClipIndex,
     hoveredClipIndex,
+    selectedCutIndex,
+    hoveredCutIndex,
     dark,
   ]);
 
@@ -358,9 +405,11 @@ export default function Timeline() {
       const t = timeFromClientX(e.clientX);
       const drag = dragRef.current;
       if (!drag) {
-        // Hover clip under cursor (waveform area)
+        // Hover clip or cut under cursor (waveform area)
         const clip = clips.find((c) => t >= c.start && t < c.end);
         setHoveredClipIndex(clip?.index ?? null);
+        const cutIdx = cuts.findIndex((c) => t >= c.start && t < c.end);
+        setHoveredCutIndex(cutIdx >= 0 ? cutIdx : null);
         const split = splits.find(
           (b) => Math.abs(t - b.time) * pps <= SPLIT_HOVER_PX
         );
@@ -390,12 +439,13 @@ export default function Timeline() {
         return;
       }
     },
-    [clips, pps, seekTo, splits, timeFromClientX]
+    [clips, cuts, pps, seekTo, splits, timeFromClientX]
   );
 
   const onPointerLeave = useCallback(() => {
     if (dragRef.current) return;
     setHoveredClipIndex(null);
+    setHoveredCutIndex(null);
     setHoveredSplitId(null);
   }, []);
 
@@ -414,15 +464,22 @@ export default function Timeline() {
 
       const t = timeFromClientX(e.clientX);
       const clip = clips.find((c) => t >= c.start && t < c.end);
+      const cutIdx = cuts.findIndex((c) => t >= c.start && t < c.end);
       const store = useEditorStore.getState();
-      store.setSelectedClipIndex(clip?.index ?? null);
-      store.setSelectedWords([]);
+      if (cutIdx >= 0) {
+        store.setSelectedCutIndex(cutIdx);
+        store.setSelectedWords([]);
+      } else {
+        store.setSelectedClipIndex(clip?.index ?? null);
+        store.setSelectedCutIndex(null);
+        store.setSelectedWords([]);
+      }
       dragRef.current = { type: "seek" };
       setDragging(true);
       e.currentTarget.setPointerCapture(e.pointerId);
       seekTo(t);
     },
-    [clips, seekTo, timeFromClientX]
+    [clips, cuts, seekTo, timeFromClientX]
   );
 
   const startWordDrag = useCallback(
@@ -578,6 +635,72 @@ export default function Timeline() {
               }`}
             >
               S
+            </kbd>
+          </button>
+
+          <button
+            type="button"
+            disabled={!ready || !deleteOk}
+            onClick={() => {
+              useEditorStore.getState().deleteSelectedClip();
+            }}
+            title={
+              deleteOk
+                ? "Delete selected clip (Delete)"
+                : "Select a clip on the timeline to delete"
+            }
+            className={`flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs font-medium transition ${
+              ready && deleteOk
+                ? "cursor-pointer text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 active:scale-[0.97] dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                : "cursor-not-allowed text-zinc-300 dark:text-zinc-600"
+            }`}
+          >
+            <Trash2 size={13} />
+            <span className="hidden sm:inline">Delete</span>
+            <kbd
+              className={`hidden rounded px-1 py-px text-[10px] font-normal sm:inline ${
+                ready && deleteOk
+                  ? "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+                  : "bg-zinc-100 text-zinc-300 dark:bg-zinc-800 dark:text-zinc-600"
+              }`}
+            >
+              ⌫
+            </kbd>
+          </button>
+
+          <button
+            type="button"
+            disabled={!ready || !restoreOk}
+            onClick={() => {
+              const store = useEditorStore.getState();
+              if (store.selectedCutIndex != null) {
+                store.restoreSelectedCut();
+              } else if (selectedWordsAllCutOut) {
+                store.restoreWords(store.selectedWordIds);
+                store.setSelectedWords([]);
+              }
+            }}
+            title={
+              restoreOk
+                ? "Restore selected cut (Delete)"
+                : "Select a cut or silence section on the timeline to restore"
+            }
+            className={`flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs font-medium transition ${
+              ready && restoreOk
+                ? "cursor-pointer text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 active:scale-[0.97] dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                : "cursor-not-allowed text-zinc-300 dark:text-zinc-600"
+            }`}
+          >
+            <RotateCcw size={13} />
+            <span className="hidden sm:inline">Restore</span>
+            <kbd
+              className={`hidden rounded px-1 py-px text-[10px] font-normal sm:inline ${
+                ready && restoreOk
+                  ? "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+                  : "bg-zinc-100 text-zinc-300 dark:bg-zinc-800 dark:text-zinc-600"
+              }`}
+            >
+              ⌫
             </kbd>
           </button>
 
@@ -761,13 +884,31 @@ export default function Timeline() {
                     e.stopPropagation();
                     seekTo(w.start);
                     const store = useEditorStore.getState();
-                    // Select the word (the transcript mirrors this) and the clip
-                    // it sits in.
+                    // Select the word (the transcript mirrors this). Kept words
+                    // also select their clip; cut-out words select the cut so
+                    // Delete / Restore can bring them back.
                     store.setSelectedWords([w.id]);
-                    const clip = clips.find(
-                      (c) => w.start >= c.start && w.start < c.end
-                    );
-                    store.setSelectedClipIndex(clip?.index ?? null);
+                    if (cutOut) {
+                      const cut = cutRangeAt(w.start + (w.end - w.start) / 2, cuts);
+                      const cutIdx = cut
+                        ? cuts.findIndex(
+                            (c) =>
+                              Math.abs(c.start - cut.start) < 1e-4 &&
+                              Math.abs(c.end - cut.end) < 1e-4
+                          )
+                        : -1;
+                      if (cutIdx >= 0) store.setSelectedCutIndex(cutIdx);
+                      else {
+                        store.setSelectedCutIndex(null);
+                        store.setSelectedClipIndex(null);
+                      }
+                    } else {
+                      const clip = clips.find(
+                        (c) => w.start >= c.start && w.start < c.end
+                      );
+                      store.setSelectedClipIndex(clip?.index ?? null);
+                      store.setSelectedCutIndex(null);
+                    }
                   }}
                 >
                   <span className="pointer-events-none min-w-0 flex-1 truncate px-1.5">

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -247,12 +247,12 @@ export default function Timeline() {
       const hovered = clip.index === hoveredClipIndex && !selected;
       if (selected) {
         ctx.fillStyle = dark ? "rgba(99, 102, 241, 0.20)" : "rgba(99, 102, 241, 0.10)";
-        // Inset + round to sit inside the selection ring (same as cuts).
+        // Match the selection ring box (vertically inset, rounded).
         roundRectPath(
           ctx,
-          x0 + SELECTION_INSET,
+          x0,
           trackTop + SELECTION_INSET,
-          x1 - x0 - SELECTION_INSET * 2,
+          x1 - x0,
           trackH - SELECTION_INSET * 2,
           SELECTION_RADIUS
         );
@@ -270,11 +270,10 @@ export default function Timeline() {
       if (x1 < 0 || x0 > width) return;
       const selected = cutIndex === selectedCutIndex;
       const hovered = cutIndex === hoveredCutIndex && !selected;
-      const fillX = selected ? x0 + SELECTION_INSET : x0;
+      // Selected fills share the ring's box so the hatch can't spill past the radius.
+      const fillX = x0;
       const fillY = selected ? trackTop + SELECTION_INSET : trackTop;
-      const fillW = selected
-        ? x1 - x0 - SELECTION_INSET * 2
-        : x1 - x0;
+      const fillW = x1 - x0;
       const fillH = selected ? trackH - SELECTION_INSET * 2 : trackH;
       ctx.fillStyle = selected
         ? dark

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -115,8 +115,11 @@ export default function Timeline() {
   const pps = fitPps * zoom;
   const totalWidth = Math.max(width, duration * pps);
   const ready = status === "ready" && duration > 0;
+  // Clip delete is for a clip-body click (no word selection). Clicking a word
+  // also selects its clip for trim handles — don't treat that as "delete clip".
   const deleteOk =
     selectedClipIndex != null &&
+    selectedWordIds.length === 0 &&
     clips.some((c) => c.index === selectedClipIndex);
   const selectedWordsAllCutOut = useMemo(() => {
     if (selectedWordIds.length === 0) return false;

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -270,22 +270,21 @@ export default function TranscriptPanel() {
     return () => document.removeEventListener("mousedown", handler);
   }, [correcting, closeCorrect]);
 
-  // Delete / Backspace cuts the selected words. Driven by the shared selection so
-  // it works for words picked in the timeline wordbar too.
+  // Escape clears the transcript selection chrome. Delete / Backspace are handled
+  // globally in Editor (cut words restore; kept words / clips delete).
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key !== "Delete" && e.key !== "Backspace" && e.key !== "Escape") return;
+      if (e.key !== "Escape") return;
       const target = e.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
         return;
       if (selectedWordIds.length === 0) return;
       e.preventDefault();
-      if (e.key !== "Escape") deleteWords(selectedWordIds);
       clearSelection();
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [selectedWordIds, deleteWords, clearSelection]);
+  }, [selectedWordIds, clearSelection]);
 
   // Keep the active word in view during playback.
   useEffect(() => {

--- a/lib/edits.ts
+++ b/lib/edits.ts
@@ -471,6 +471,37 @@ export function carrySceneBoundaries(
 }
 
 /**
+ * Restore media in the given cut ranges: shrink overlapping manual cuts and
+ * undelete words fully covered by each range. Inverse of cutting a clip / silence.
+ */
+export function restoreRangesResult(
+  words: Word[],
+  manualCuts: ManualCut[],
+  ranges: TimeRange[],
+  nextCutId: number
+): { words: Word[]; manualCuts: ManualCut[]; nextCutId: number } | null {
+  const usable = ranges.filter((r) => r.end - r.start > 1e-4);
+  if (usable.length === 0) return null;
+
+  let nextWords = words;
+  let cuts = manualCuts;
+  let id = nextCutId;
+  let changed = false;
+
+  for (const r of usable) {
+    const shrunk = shrinkManualCuts(cuts, r.start, r.end, id);
+    const restored = restoreWordsCoveredBy(nextWords, r.start, r.end);
+    if (shrunk.cuts !== cuts || restored !== nextWords) changed = true;
+    cuts = shrunk.cuts;
+    id = shrunk.nextId;
+    nextWords = restored;
+  }
+
+  if (!changed) return null;
+  return { words: nextWords, manualCuts: cuts, nextCutId: id };
+}
+
+/**
  * Move one kept-region edge from `from` to `to`. `edge` names the side that
  * stays kept ("out" = the clip left of the edge, "in" = the clip right of it),
  * which is what decides whether the move cuts the span away or reclaims it.

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -21,6 +21,7 @@ import {
   getCutRanges,
   getKeepRanges,
   PLAYHEAD_EPSILON_S,
+  restoreRangesResult,
   shrinkManualCuts,
   trimEdgeResult,
 } from "./edits";
@@ -88,6 +89,11 @@ interface EditorState {
   /** Selected timeline clip index, or null. */
   selectedClipIndex: number | null;
   /**
+   * Selected cut-range index (from `getCutRanges`), or null.
+   * Used to restore a deleted clip / silence section from the timeline.
+   */
+  selectedCutIndex: number | null;
+  /**
    * Words selected in the transcript or the timeline wordbar. Shared so both
    * views highlight the same selection and the same shortcuts apply.
    */
@@ -135,6 +141,12 @@ interface EditorState {
   restoreWords: (ids: number[]) => void;
   /** Cut arbitrary time ranges (e.g. detected silences) as manual cuts. */
   cutRanges: (ranges: TimeRange[]) => void;
+  /** Restore arbitrary cut ranges (manual cuts + covered deleted words). */
+  restoreRanges: (ranges: TimeRange[]) => void;
+  /** Cut the currently selected timeline clip out of the edited media. */
+  deleteSelectedClip: () => boolean;
+  /** Restore the currently selected cut range (deleted clip / silence). */
+  restoreSelectedCut: () => boolean;
   /** Replace the selected (contiguous) words with corrected text. */
   correctWords: (ids: number[], text: string) => void;
   /** Nudge a word's start/end on the timeline (may steal time from neighbors). */
@@ -152,6 +164,7 @@ interface EditorState {
    */
   trimEdge: (edge: "in" | "out", from: number, to: number) => void;
   setSelectedClipIndex: (index: number | null) => void;
+  setSelectedCutIndex: (index: number | null) => void;
   setSelectedWords: (ids: number[]) => void;
   /** Start a drag gesture so subsequent edits share one undo entry. */
   beginGesture: () => void;
@@ -214,6 +227,7 @@ function pushEdit(
       | "manualCuts"
       | "sceneBoundaries"
       | "selectedClipIndex"
+      | "selectedCutIndex"
       | "selectedWordIds"
       | "nextManualCutId"
       | "nextBoundaryId"
@@ -258,6 +272,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   past: [],
   future: [],
   selectedClipIndex: null,
+  selectedCutIndex: null,
   selectedWordIds: [],
   nextManualCutId: 1,
   nextBoundaryId: 1,
@@ -297,6 +312,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           past: [],
       future: [],
       selectedClipIndex: null,
+      selectedCutIndex: null,
       selectedWordIds: [],
       nextManualCutId: 1,
       nextBoundaryId: 1,
@@ -339,6 +355,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       past: [],
       future: [],
       selectedClipIndex: null,
+      selectedCutIndex: null,
       selectedWordIds: [],
       nextManualCutId: maxId(manualCuts, 1),
       nextBoundaryId: maxId(sceneBoundaries, 1),
@@ -392,6 +409,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           past: [],
       future: [],
       selectedClipIndex: null,
+      selectedCutIndex: null,
       selectedWordIds: [],
     });
     if (get().status === "ready") bumpAutosave();
@@ -415,6 +433,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           past: [],
       future: [],
       selectedClipIndex: null,
+      selectedCutIndex: null,
       selectedWordIds: [],
       partialText: "",
       error: null,
@@ -434,6 +453,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       words: words.map((w) =>
         idSet.has(w.id) && !w.deleted ? { ...w, deleted: true } : w
       ),
+      selectedCutIndex: null,
     });
   },
   cutRanges: (ranges) => {
@@ -449,7 +469,54 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       nextManualCutId = added.nextId;
       words = deleteWordsCoveredBy(words, r.start, r.end);
     }
-    pushEdit(get, set, { words, manualCuts, nextManualCutId });
+    pushEdit(get, set, {
+      words,
+      manualCuts,
+      nextManualCutId,
+      selectedClipIndex: null,
+      selectedCutIndex: null,
+      selectedWordIds: [],
+    });
+  },
+  restoreRanges: (ranges) => {
+    const s = get();
+    const result = restoreRangesResult(
+      s.words,
+      s.manualCuts,
+      ranges,
+      s.nextManualCutId
+    );
+    if (!result) return;
+    pushEdit(get, set, {
+      words: result.words,
+      manualCuts: result.manualCuts,
+      nextManualCutId: result.nextCutId,
+      selectedClipIndex: null,
+      selectedCutIndex: null,
+      selectedWordIds: [],
+    });
+  },
+  deleteSelectedClip: () => {
+    const s = get();
+    if (s.selectedClipIndex == null || s.duration <= 0) return false;
+    const cuts = getCutRanges(s.words, s.duration, s.manualCuts);
+    const clips = getClipSegments(
+      getKeepRanges(cuts, s.duration),
+      s.sceneBoundaries
+    );
+    const clip = clips.find((c) => c.index === s.selectedClipIndex);
+    if (!clip || clip.end - clip.start <= 1e-4) return false;
+    get().cutRanges([{ start: clip.start, end: clip.end }]);
+    return true;
+  },
+  restoreSelectedCut: () => {
+    const s = get();
+    if (s.selectedCutIndex == null || s.duration <= 0) return false;
+    const cuts = getCutRanges(s.words, s.duration, s.manualCuts);
+    const cut = cuts[s.selectedCutIndex];
+    if (!cut || cut.end - cut.start <= 1e-4) return false;
+    get().restoreRanges([{ start: cut.start, end: cut.end }]);
+    return true;
   },
   restoreWords: (ids) => {
     if (ids.length === 0) return;
@@ -481,6 +548,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       words,
       manualCuts,
       nextManualCutId,
+      selectedCutIndex: null,
     });
   },
   correctWords: (ids, text) => {
@@ -559,6 +627,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     pushEdit(get, set, {
       sceneBoundaries: sceneBoundaries.filter((b) => b.id !== id),
       selectedClipIndex: null,
+      selectedCutIndex: null,
     });
   },
 
@@ -597,12 +666,29 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       sceneBoundaries,
       nextManualCutId: result.nextCutId,
       selectedClipIndex: owner?.index ?? s.selectedClipIndex,
+      selectedCutIndex: null,
     });
   },
 
-  setSelectedClipIndex: (selectedClipIndex) => set({ selectedClipIndex }),
+  setSelectedClipIndex: (selectedClipIndex) =>
+    set({
+      selectedClipIndex,
+      ...(selectedClipIndex != null ? { selectedCutIndex: null } : {}),
+    }),
 
-  setSelectedWords: (selectedWordIds) => set({ selectedWordIds }),
+  setSelectedCutIndex: (selectedCutIndex) =>
+    set({
+      selectedCutIndex,
+      ...(selectedCutIndex != null ? { selectedClipIndex: null } : {}),
+    }),
+
+  setSelectedWords: (selectedWordIds) =>
+    set({
+      selectedWordIds,
+      // A fresh word selection from the transcript supersedes a prior cut pick.
+      // Timeline cut-word clicks re-select the cut afterward.
+      ...(selectedWordIds.length > 0 ? { selectedCutIndex: null } : {}),
+    }),
 
   beginGesture: () => {
     const s = get();
@@ -641,6 +727,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
         ...future,
       ],
       selectedClipIndex: null,
+      selectedCutIndex: null,
       selectedWordIds: [],
       gestureActive: false,
     });
@@ -658,6 +745,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       future: future.slice(1),
       past: [...past, { words, manualCuts, sceneBoundaries }],
       selectedClipIndex: null,
+      selectedCutIndex: null,
       selectedWordIds: [],
       gestureActive: false,
     });
@@ -718,6 +806,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           past: [],
       future: [],
       selectedClipIndex: null,
+      selectedCutIndex: null,
       selectedWordIds: [],
       nextManualCutId: 1,
       nextBoundaryId: 1,

--- a/tests/edits-test.ts
+++ b/tests/edits-test.ts
@@ -14,6 +14,7 @@ import {
   getWordCutRanges,
   mapSplitsToWords,
   MIN_CLIP_DURATION,
+  restoreRangesResult,
   trimEdgeBounds,
   trimEdgeResult,
 } from "../lib/edits";
@@ -293,6 +294,71 @@ function nearly(a: number, b: number, eps = 1e-3) {
   assert(next !== null, "word bounds applied");
   assert(nearly(getCutRanges(next!, 2)[0].start, 0.55), "cut start follows the word");
   assert(nearly(next![0].end, 0.55), "hello keeps its audio");
+}
+
+// --- Restoring a cut range undeletes words and shrinks manual cuts ---
+{
+  const words = [
+    word(1, "keep", 0, 1),
+    word(2, "gone", 1, 2, true),
+    word(3, "also", 2, 3, true),
+    word(4, "end", 3, 4),
+  ];
+  const manual: ManualCut[] = [{ id: 1, start: 1, end: 3 }];
+  const result = restoreRangesResult(words, manual, [{ start: 1, end: 3 }], 10);
+  assert(result !== null, "restore ok");
+  assert(result!.words[1].deleted === false, "gone restored");
+  assert(result!.words[2].deleted === false, "also restored");
+  assert(result!.manualCuts.length === 0, "manual cut removed");
+  const keeps = getKeepRanges(
+    getCutRanges(result!.words, 4, result!.manualCuts),
+    4
+  );
+  assert(keeps.length === 1, "one continuous keep after restore");
+}
+
+// --- Partial restore splits a manual cut (only fully covered words return) ---
+{
+  const words = [
+    word(1, "left", 0, 1, true),
+    word(2, "mid", 1, 3, true),
+    word(3, "right", 3, 5, true),
+  ];
+  const manual: ManualCut[] = [{ id: 1, start: 0, end: 5 }];
+  const result = restoreRangesResult(words, manual, [{ start: 1, end: 3 }], 10);
+  assert(result !== null, "partial restore ok");
+  assert(result!.words[0].deleted === true, "left stays cut");
+  assert(result!.words[1].deleted === false, "mid restored");
+  assert(result!.words[2].deleted === true, "right stays cut");
+  assert(result!.manualCuts.length === 2, "manual cut split into remnants");
+  assert(nearly(result!.manualCuts[0].end, 1), "left remnant");
+  assert(nearly(result!.manualCuts[1].start, 3), "right remnant");
+}
+
+// --- Delete clip then restore that cut brings media back ---
+{
+  const words = [
+    word(1, "a", 0, 2),
+    word(2, "b", 2, 4),
+    word(3, "c", 4, 6),
+  ];
+  // Simulate deleting the middle clip [2,4) via a manual cut + covered words.
+  const cut = trimEdgeResult(words, [], "out", 4, 2, 1);
+  assert(cut !== null, "cut middle");
+  assert(cut!.words[1].deleted === true, "b deleted");
+  const restored = restoreRangesResult(
+    cut!.words,
+    cut!.manualCuts,
+    [{ start: 2, end: 4 }],
+    cut!.nextCutId
+  );
+  assert(restored !== null, "restore middle");
+  assert(restored!.words[1].deleted === false, "b back");
+  assert(
+    getKeepRanges(getCutRanges(restored!.words, 6, restored!.manualCuts), 6)
+      .length === 1,
+    "fully restored keep"
+  );
 }
 
 console.log("edits-test: all passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds first-class **delete** and **restore** for timeline clips, wired into the existing cut/keep model (manual cuts + deleted words).

### Delete a clip
- Click a kept clip on the timeline, then press **Delete/Backspace**, or use the new **Delete** button next to Split
- Cuts the clip’s time range out of the edited media (same path as silence removal / aggressive trim)

### Restore a cut
- Click a red cut/silence section (or a cut-out word on the wordbar), then press **Delete/Backspace**, or use the new **Restore** button
- Shrinks overlapping manual cuts and undeletes covered words so that media returns to the keep ranges

### Shortcuts
Delete/Backspace is context-sensitive (handled globally in `Editor`):
1. Selected cut region → restore
2. Selected words → restore if all cut out, otherwise cut kept words
3. Selected clip (no words) → delete clip

### Implementation notes
- New `restoreRangesResult` in `lib/edits.ts` + store actions `restoreRanges`, `deleteSelectedClip`, `restoreSelectedCut`
- Timeline cut ranges are selectable (`selectedCutIndex`), with stronger selection wash
- Unit coverage for restore round-trips in `tests/edits-test.ts` (`npx tsx tests/edits-test.ts` passes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc260-04e8-761d-9fd3-ca5074819959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc260-04e8-761d-9fd3-ca5074819959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

