### PR TITLE
Re-enable short Whisper filler prompts for um/uh retention

### DIFF
--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,3 +1,5 @@
+import type { TranscriptLanguage } from "./languages";
+
 /** Local speech models offered on the upload screen. */
 export type WhisperModel = "base" | "small";
 /** NVIDIA Parakeet TDT 0.6B v3 via parakeet.js (ONNX / WebGPU). */
@@ -24,16 +26,14 @@ export type WhisperModelInfo = ModelDisplay & {
     wasm: Record<string, DType>;
   };
   /**
-   * Whisper is trained to produce "clean" transcripts and usually drops
-   * disfluencies. Conditioning the decoder on a prompt that itself contains
-   * fillers biases it toward verbatim output. The prompt is injected as
-   * `<|startofprev|> …prompt… <|startoftranscript|>` decoder tokens.
+   * When true, condition Whisper on a short filler-rich initial prompt so
+   * "Remove fillers" has tokens to act on. See {@link whisperFillerPrompt}.
    *
    * (A dedicated verbatim model — CrisperWhisper — was evaluated, but its
    * only browser-runnable ONNX export lacks the cross-attention outputs
    * required for word-level timestamps, which this editor depends on.)
    */
-  verbatimPrompt?: string;
+  keepFillers?: boolean;
 };
 
 export type ParakeetModelInfo = ModelDisplay & {
@@ -49,6 +49,39 @@ export type ModelInfo = WhisperModelInfo | ParakeetModelInfo;
 /** Display order for model rows in the source dropdown. */
 export const MODEL_ORDER: ModelId[] = ["base", "small", "parakeet"];
 
+/**
+ * Hard cap for Whisper filler prompts. Longer `<|startofprev|>` strings
+ * forced via `decoder_input_ids` have truncated multi-speaker / long-form
+ * transcripts (second speaker dropped). Keep prompts to a short filler list.
+ */
+export const MAX_VERBATIM_PROMPT_LENGTH = 32;
+
+/**
+ * Short, language-specific filler prompts for Whisper. Deliberately tiny and
+ * free of "I'm …" openers (those seeded "I'm sorry" hallucination loops).
+ * The classic OpenAI example prompt is too long for our chunked decoder path.
+ */
+const WHISPER_FILLER_PROMPTS: Record<TranscriptLanguage, string> = {
+  en: "Um, uh, hmm, er, ah.",
+  es: "Em, emm, eee.",
+  fr: "Euh, heu, euhm.",
+  de: "Äh, ähm, öhm, mhh.",
+  zh: "嗯, 呃, 额, 唔.",
+};
+
+/**
+ * Filler-bias prompt for Whisper when the selected model opts into
+ * {@link WhisperModelInfo.keepFillers}. Returns null when prompting is off.
+ */
+export function whisperFillerPrompt(
+  model: ModelId,
+  language: TranscriptLanguage
+): string | null {
+  const info = MODELS[model];
+  if (info.backend !== "whisper" || !info.keepFillers) return null;
+  return WHISPER_FILLER_PROMPTS[language];
+}
+
 const WHISPER_DTYPE = {
   // q4 decoder: q8 fails session creation on onnxruntime-web 1.26
   // (Missing required scale … MatMulNBits).
@@ -59,7 +92,7 @@ const WHISPER_DTYPE = {
 /**
  * Local speech models that can run in the transcription worker.
  * Shared display fields live on every entry; backend-specific knobs
- * (`dtype` / `verbatimPrompt` vs `repoId`) are gated by `backend`.
+ * (`dtype` / `keepFillers` vs `repoId`) are gated by `backend`.
  */
 export const MODELS: {
   base: WhisperModelInfo;
@@ -73,9 +106,8 @@ export const MODELS: {
     description: "Faster download and transcription. Good for most clips.",
     size: "~200 MB",
     dtype: WHISPER_DTYPE,
-    // Do not set verbatimPrompt: forcing a long <|startofprev|> prompt via
-    // decoder_input_ids truncates long-form transcripts (e.g. drops the second
-    // speaker on mixed clips). Prefer post-process / filler tools instead.
+    // Short filler prompt only — long prompts truncate long-form ASR.
+    keepFillers: true,
   },
   small: {
     backend: "whisper",
@@ -84,6 +116,7 @@ export const MODELS: {
     description: "More accurate on longer or noisier audio. Larger download.",
     size: "~600 MB",
     dtype: WHISPER_DTYPE,
+    keepFillers: true,
   },
   parakeet: {
     backend: "parakeet",

--- a/tests/models-test.ts
+++ b/tests/models-test.ts
@@ -2,11 +2,13 @@
  * Model + transcript-source helpers.
  */
 import {
+  MAX_VERBATIM_PROMPT_LENGTH,
   MODEL_ORDER,
   MODELS,
   isModelId,
   isParakeetModel,
   isWhisperModel,
+  whisperFillerPrompt,
 } from "../lib/models";
 import { isTranscriptSource } from "../lib/source";
 
@@ -36,6 +38,8 @@ assert(MODELS.base.backend === "whisper", "base backend");
 assert(typeof MODELS.base.id === "string", "whisper base id");
 assert(typeof MODELS.small.id === "string", "whisper small id");
 assert(MODELS.base.dtype.webgpu.encoder_model === "fp32", "whisper dtype");
+assert(MODELS.base.keepFillers === true, "base keeps fillers");
+assert(MODELS.small.keepFillers === true, "small keeps fillers");
 
 assert(
   MODEL_ORDER.includes("parakeet") && MODEL_ORDER.includes("base"),
@@ -46,5 +50,13 @@ for (const id of MODEL_ORDER) {
   assert(typeof MODELS[id].label === "string", `${id} has label`);
   assert(typeof MODELS[id].size === "string", `${id} has size`);
 }
+
+assert(whisperFillerPrompt("base", "en") === "Um, uh, hmm, er, ah.", "en prompt");
+assert(whisperFillerPrompt("small", "de") === "Äh, ähm, öhm, mhh.", "de prompt");
+assert(whisperFillerPrompt("parakeet", "en") === null, "parakeet has no prompt");
+assert(
+  (whisperFillerPrompt("base", "en")?.length ?? 0) <= MAX_VERBATIM_PROMPT_LENGTH,
+  "en prompt within length cap"
+);
 
 console.log("models-test: ok");

--- a/tests/vad-regression-test.ts
+++ b/tests/vad-regression-test.ts
@@ -14,7 +14,15 @@ import {
   speechSegmentsFromFrames,
   VAD_SAMPLE_RATE,
 } from "../lib/vad";
-import { MODELS } from "../lib/models";
+import {
+  MAX_VERBATIM_PROMPT_LENGTH,
+  MODELS,
+  whisperFillerPrompt,
+} from "../lib/models";
+import {
+  TRANSCRIPT_LANGUAGE_ORDER,
+  type TranscriptLanguage,
+} from "../lib/languages";
 
 const wav = path.join(
   process.cwd(),
@@ -30,16 +38,29 @@ function ffmpegAvailable(): boolean {
   return probe.status === 0;
 }
 
-// Long decoder prompts truncate long-form ASR — Whisper models must not set them.
+// Short filler prompts are OK; long ones truncate multi-speaker / long-form ASR.
 for (const id of Object.keys(MODELS) as (keyof typeof MODELS)[]) {
   const info = MODELS[id];
   if (info.backend !== "whisper") continue;
-  assert(
-    !info.verbatimPrompt,
-    `${id} must not set verbatimPrompt (truncates multi-speaker clips)`
-  );
+  assert(info.keepFillers === true, `${id} should keep fillers via a short prompt`);
+  for (const language of TRANSCRIPT_LANGUAGE_ORDER) {
+    const prompt = whisperFillerPrompt(id, language);
+    assert(!!prompt, `${id}/${language} must resolve a filler prompt`);
+    assert(
+      prompt!.length <= MAX_VERBATIM_PROMPT_LENGTH,
+      `${id}/${language} filler prompt too long (${prompt!.length} > ${MAX_VERBATIM_PROMPT_LENGTH})`
+    );
+    assert(
+      !/\bI'm\b/i.test(prompt!),
+      `${id}/${language} filler prompt must not contain "I'm" (seeds hallucination loops)`
+    );
+  }
 }
-console.log("models have no verbatimPrompt: ok");
+assert(
+  whisperFillerPrompt("parakeet", "en" as TranscriptLanguage) === null,
+  "parakeet must not use Whisper filler prompts"
+);
+console.log("whisper filler prompts stay short: ok");
 
 const workerSrc = fs.readFileSync(
   path.join(process.cwd(), "workers/transcription.worker.ts"),

--- a/workers/transcription.worker.ts
+++ b/workers/transcription.worker.ts
@@ -32,6 +32,7 @@ import {
   MODELS,
   isParakeetModel,
   isWhisperModel,
+  whisperFillerPrompt,
   type ModelId,
   type WhisperModel,
 } from "@/lib/models";
@@ -683,12 +684,14 @@ async function runWhisper(
   const { segments: speechSegments, frames: speechFrames } =
     await detectSpeechSegments(audio, vad);
 
-  const { verbatimPrompt } = MODELS[choice];
-  const promptedIds = verbatimPrompt
-    ? buildPromptedDecoderIds(transcriber, verbatimPrompt, transcriptLanguage)
+  // Short filler-rich <|startofprev|> prompt so um/uh survive for "Remove
+  // fillers". Long prompts truncate multi-speaker clips — see whisperFillerPrompt.
+  const fillerPrompt = whisperFillerPrompt(choice, transcriptLanguage);
+  const promptedIds = fillerPrompt
+    ? buildPromptedDecoderIds(transcriber, fillerPrompt, transcriptLanguage)
     : null;
-  if (verbatimPrompt && !promptedIds) {
-    console.warn("Could not build verbatim prompt tokens; using default decoding.");
+  if (fillerPrompt && !promptedIds) {
+    console.warn("Could not build filler prompt tokens; using default decoding.");
   }
 
   const speechSamples = speechSegments.reduce(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Stock Whisper cleans disfluencies, so **Remove fillers** often has nothing to cut. This restores `<|startofprev|>` filler prompting for Whisper Base/Small, but with the safer short prompts we learned we need:

- Short language-specific prompts (`Um, uh, hmm, er, ah.` and DE/FR/ES/ZH equivalents)
- Hard length cap (≤32 chars) — the long OpenAI-style prompt previously truncated multi-speaker / long-form ASR
- No `I'm …` openers (those seeded `"I'm sorry"` hallucination loops)

Parakeet is unchanged (no Whisper prompt path).

## Changes
- `keepFillers` flag on Whisper models + `whisperFillerPrompt(model, language)`
- Worker uses the resolved short prompt via existing `buildPromptedDecoderIds`
- Regression test now **requires** short prompts (instead of forbidding all prompts)

## Test plan
- [x] `npx tsx tests/models-test.ts`
- [x] `npx tsx tests/vad-regression-test.ts`
- [x] `npx tsx tests/fillers-test.ts`
- [ ] Manual: transcribe a clip with audible um/uh on Whisper Base and confirm fillers appear so **Remove fillers** is enabled
- [ ] Manual: multi-speaker clip still keeps both speakers (no second-speaker drop)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc3e2-1849-71bc-a149-6354f42cf275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc3e2-1849-71bc-a149-6354f42cf275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

