### PR TITLE
Pause transcript auto-scroll on manual scroll

### DIFF
--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -38,6 +38,7 @@ import {
   mapSplitsToWords,
 } from "@/lib/edits";
 import { useTranscriptSelection } from "@/hooks/useTranscriptSelection";
+import { useTranscriptPlayheadFollow } from "@/hooks/useTranscriptPlayheadFollow";
 import { useCutRanges } from "@/hooks/useCutRanges";
 import { findActiveWordId, groupWordsBySpeaker } from "@/lib/transcript";
 
@@ -145,15 +146,6 @@ export default function TranscriptPanel() {
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
-  // Playhead follow: auto-scroll while true; manual scroll turns it off.
-  const followPlayheadRef = useRef(true);
-  /** Set by wheel/touch/rail before the matching scroll event. */
-  const userScrollGestureRef = useRef(false);
-  const [followPlayhead, setFollowPlayhead] = useState(true);
-  /** Playhead outside the readable viewport — gates the Follow control. */
-  const [playheadOffscreen, setPlayheadOffscreen] = useState(false);
-  /** Which way to jump to the playhead when unfollowed. */
-  const [followDirection, setFollowDirection] = useState<"up" | "down">("down");
   const [correcting, setCorrecting] = useState<{
     ids: number[];
     top: number;
@@ -182,58 +174,17 @@ export default function TranscriptPanel() {
     freezeSelectionRef,
   });
 
-  /** Measure whether the active word sits above/below the readable pane. */
-  const measurePlayheadAnchor = useCallback(() => {
-    const scroller = scrollRef.current;
-    if (!scroller) return { offscreen: false as const };
-    const { words, currentTime } = useEditorStore.getState();
-    const activeId = findActiveWordId(words, currentTime);
-    if (activeId < 0) {
-      setPlayheadOffscreen(false);
-      return { offscreen: false as const };
-    }
-    const el = containerRef.current?.querySelector(`[data-wid="${activeId}"]`);
-    if (!el) {
-      setPlayheadOffscreen(false);
-      return { offscreen: false as const };
-    }
-    const wordRect = el.getBoundingClientRect();
-    const scrollerRect = scroller.getBoundingClientRect();
-    // Header overlays the top of the scroller (pt-10 / scroll-pt-10).
-    const viewTop = scrollerRect.top + 40;
-    const viewBottom = scrollerRect.bottom;
-    if (wordRect.bottom < viewTop) {
-      setPlayheadOffscreen(true);
-      setFollowDirection("up");
-      return { offscreen: true as const, direction: "up" as const };
-    }
-    if (wordRect.top > viewBottom) {
-      setPlayheadOffscreen(true);
-      setFollowDirection("down");
-      return { offscreen: true as const, direction: "down" as const };
-    }
-    setPlayheadOffscreen(false);
-    return { offscreen: false as const };
-  }, []);
-
-  /** Rail / gesture hint — actual unfollow waits until scroll leaves the word. */
-  const userScrollGestureTimerRef = useRef(0);
-  const markUserScrollGesture = useCallback(() => {
-    const scroller = scrollRef.current;
-    if (!scroller || scroller.scrollHeight <= scroller.clientHeight + 1) return;
-    userScrollGestureRef.current = true;
-    // Keep the gesture armed across momentum / rail-drag scroll bursts.
-    window.clearTimeout(userScrollGestureTimerRef.current);
-    userScrollGestureTimerRef.current = window.setTimeout(() => {
-      userScrollGestureRef.current = false;
-    }, 150);
-  }, []);
-
-  const resumeFollowPlayhead = useCallback(() => {
-    followPlayheadRef.current = true;
-    setFollowPlayhead(true);
-    setPlayheadOffscreen(false);
-  }, []);
+  const {
+    showFollowControl,
+    followDirection,
+    resumeFollowPlayhead,
+    markUserScrollGesture,
+  } = useTranscriptPlayheadFollow({
+    scrollRef,
+    containerRef,
+    playing,
+    activeWordId,
+  });
 
   // Clicking a word seeks — resume following so playback stays in view.
   const onWordClick = useCallback(
@@ -388,54 +339,6 @@ export default function TranscriptPanel() {
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [selection, assigningSpeaker, correcting, openSpeakerAssign]);
-
-  // User scroll pauses follow only once the active word actually leaves view.
-  // Wheel over a non-scrollable pane is ignored (no Follow chip).
-  useEffect(() => {
-    const scroller = scrollRef.current;
-    if (!scroller) return;
-    const onGesture = () => markUserScrollGesture();
-    const onScroll = () => {
-      if (!playing) return;
-      const { offscreen } = measurePlayheadAnchor();
-      if (userScrollGestureRef.current && offscreen) {
-        followPlayheadRef.current = false;
-        setFollowPlayhead(false);
-        return;
-      }
-      // Scrolled back onto the playhead (or programmatic nearest kept it in view).
-      if (!offscreen && !followPlayheadRef.current) resumeFollowPlayhead();
-    };
-    scroller.addEventListener("wheel", onGesture, { passive: true });
-    scroller.addEventListener("touchmove", onGesture, { passive: true });
-    scroller.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      scroller.removeEventListener("wheel", onGesture);
-      scroller.removeEventListener("touchmove", onGesture);
-      scroller.removeEventListener("scroll", onScroll);
-      window.clearTimeout(userScrollGestureTimerRef.current);
-    };
-  }, [markUserScrollGesture, measurePlayheadAnchor, resumeFollowPlayhead, playing]);
-
-  // Keep the active word in view during playback while following.
-  useEffect(() => {
-    if (!playing || !followPlayhead || activeWordId < 0) return;
-    const el = containerRef.current?.querySelector(`[data-wid="${activeWordId}"]`);
-    el?.scrollIntoView({ block: "nearest" });
-  }, [activeWordId, playing, followPlayhead]);
-
-  // Refresh offscreen/direction as the playhead advances while unfollowed.
-  useEffect(() => {
-    if (followPlayhead || !playing || activeWordId < 0) return;
-    const { offscreen } = measurePlayheadAnchor();
-    if (!offscreen) resumeFollowPlayhead();
-  }, [
-    followPlayhead,
-    playing,
-    activeWordId,
-    measurePlayheadAnchor,
-    resumeFollowPlayhead,
-  ]);
 
   const busy = status === "preparing" || status === "transcribing";
 
@@ -688,7 +591,7 @@ export default function TranscriptPanel() {
       </div>
       {/* Gradient overlay — must match the transcript panel surface */}
       <div className="absolute z-10 pointer-events-none inset-x-0 bottom-0 w-full h-20 bg-gradient-to-t from-white to-transparent dark:from-zinc-900" />
-      {!followPlayhead && playheadOffscreen && playing && activeWordId >= 0 && (
+      {showFollowControl && (
         <button
           type="button"
           onClick={resumeFollowPlayhead}

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -2,10 +2,11 @@
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ArrowDown,
+  ArrowUp,
   ArrowUpFromLine,
   Eye,
   EyeOff,
-  LocateFixed,
   Merge,
   Pencil,
   RotateCcw,
@@ -147,6 +148,8 @@ export default function TranscriptPanel() {
   // Playhead follow: auto-scroll while true; manual scroll turns it off.
   const followPlayheadRef = useRef(true);
   const [followPlayhead, setFollowPlayhead] = useState(true);
+  /** Which way to jump to the playhead when unfollowed. */
+  const [followDirection, setFollowDirection] = useState<"up" | "down">("down");
   const [correcting, setCorrecting] = useState<{
     ids: number[];
     top: number;
@@ -175,11 +178,29 @@ export default function TranscriptPanel() {
     freezeSelectionRef,
   });
 
+  const updateFollowDirection = useCallback(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    const { words, currentTime } = useEditorStore.getState();
+    const activeId = findActiveWordId(words, currentTime);
+    if (activeId < 0) return;
+    const el = containerRef.current?.querySelector(`[data-wid="${activeId}"]`);
+    if (!el) return;
+    const wordRect = el.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+    // Header overlays the top of the scroller (pt-10 / scroll-pt-10).
+    const viewTop = scrollerRect.top + 40;
+    const viewBottom = scrollerRect.bottom;
+    if (wordRect.bottom < viewTop) setFollowDirection("up");
+    else if (wordRect.top > viewBottom) setFollowDirection("down");
+  }, []);
+
   const unfollowPlayhead = useCallback(() => {
     if (!followPlayheadRef.current) return;
     followPlayheadRef.current = false;
     setFollowPlayhead(false);
-  }, []);
+    updateFollowDirection();
+  }, [updateFollowDirection]);
 
   const resumeFollowPlayhead = useCallback(() => {
     followPlayheadRef.current = true;
@@ -361,6 +382,17 @@ export default function TranscriptPanel() {
     const el = containerRef.current?.querySelector(`[data-wid="${activeWordId}"]`);
     el?.scrollIntoView({ block: "nearest" });
   }, [activeWordId, playing, followPlayhead]);
+
+  // Keep the Follow button arrow pointed toward the active word.
+  useEffect(() => {
+    if (followPlayhead || !playing || activeWordId < 0) return;
+    updateFollowDirection();
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    const onScroll = () => updateFollowDirection();
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => scroller.removeEventListener("scroll", onScroll);
+  }, [followPlayhead, playing, activeWordId, updateFollowDirection]);
 
   const busy = status === "preparing" || status === "transcribing";
 
@@ -620,7 +652,7 @@ export default function TranscriptPanel() {
           title="Scroll with the playhead"
           className="absolute bottom-5 left-1/2 z-20 flex -translate-x-1/2 cursor-pointer items-center gap-1.5 rounded-full border border-zinc-200 bg-white/95 px-3 py-1.5 text-xs font-medium text-zinc-700 shadow-md shadow-zinc-900/10 backdrop-blur-sm transition hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/95 dark:text-zinc-200 dark:shadow-black/30 dark:hover:bg-zinc-700"
         >
-          <LocateFixed size={13} />
+          {followDirection === "up" ? <ArrowUp size={13} /> : <ArrowDown size={13} />}
           Follow playhead
         </button>
       )}

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpFromLine,
   Eye,
   EyeOff,
+  LocateFixed,
   Merge,
   Pencil,
   RotateCcw,
@@ -143,6 +144,9 @@ export default function TranscriptPanel() {
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
+  // Playhead follow: auto-scroll while true; manual scroll turns it off.
+  const followPlayheadRef = useRef(true);
+  const [followPlayhead, setFollowPlayhead] = useState(true);
   const [correcting, setCorrecting] = useState<{
     ids: number[];
     top: number;
@@ -170,6 +174,26 @@ export default function TranscriptPanel() {
     cutOutIds,
     freezeSelectionRef,
   });
+
+  const unfollowPlayhead = useCallback(() => {
+    if (!followPlayheadRef.current) return;
+    followPlayheadRef.current = false;
+    setFollowPlayhead(false);
+  }, []);
+
+  const resumeFollowPlayhead = useCallback(() => {
+    followPlayheadRef.current = true;
+    setFollowPlayhead(true);
+  }, []);
+
+  // Clicking a word seeks — resume following so playback stays in view.
+  const onWordClick = useCallback(
+    (word: Word, el: HTMLElement) => {
+      resumeFollowPlayhead();
+      handleWordClick(word, el);
+    },
+    [handleWordClick, resumeFollowPlayhead]
+  );
 
   const turns = useMemo(() => groupWordsBySpeaker(words), [words]);
 
@@ -316,12 +340,27 @@ export default function TranscriptPanel() {
     return () => document.removeEventListener("keydown", handler);
   }, [selection, assigningSpeaker, correcting, openSpeakerAssign]);
 
-  // Keep the active word in view during playback.
+  // User scroll gestures pause playhead follow (not programmatic scrollIntoView).
+  // Native scrollbar is hidden — wheel/touch cover trackpads; the custom rail
+  // reports via onUserScroll. Avoid pointerdown here so word clicks don't unfollow.
   useEffect(() => {
-    if (!playing || activeWordId < 0) return;
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    const onIntent = () => unfollowPlayhead();
+    scroller.addEventListener("wheel", onIntent, { passive: true });
+    scroller.addEventListener("touchmove", onIntent, { passive: true });
+    return () => {
+      scroller.removeEventListener("wheel", onIntent);
+      scroller.removeEventListener("touchmove", onIntent);
+    };
+  }, [unfollowPlayhead]);
+
+  // Keep the active word in view during playback while following.
+  useEffect(() => {
+    if (!playing || !followPlayhead || activeWordId < 0) return;
     const el = containerRef.current?.querySelector(`[data-wid="${activeWordId}"]`);
     el?.scrollIntoView({ block: "nearest" });
-  }, [activeWordId, playing]);
+  }, [activeWordId, playing, followPlayhead]);
 
   const busy = status === "preparing" || status === "transcribing";
 
@@ -470,7 +509,7 @@ export default function TranscriptPanel() {
                               word={w}
                               cutOut={cutOutIds.has(w.id)}
                               active={w.id === activeWordId}
-                              onClick={handleWordClick}
+                              onClick={onWordClick}
                             />
                           </React.Fragment>
                         );
@@ -574,7 +613,22 @@ export default function TranscriptPanel() {
       </div>
       {/* Gradient overlay — must match the transcript panel surface */}
       <div className="absolute z-10 pointer-events-none inset-x-0 bottom-0 w-full h-20 bg-gradient-to-t from-white to-transparent dark:from-zinc-900" />
-      <TranscriptScrollIndicator scrollRef={scrollRef} contentRef={containerRef} />
+      {!followPlayhead && playing && activeWordId >= 0 && (
+        <button
+          type="button"
+          onClick={resumeFollowPlayhead}
+          title="Scroll with the playhead"
+          className="absolute bottom-5 left-1/2 z-20 flex -translate-x-1/2 cursor-pointer items-center gap-1.5 rounded-full border border-zinc-200 bg-white/95 px-3 py-1.5 text-xs font-medium text-zinc-700 shadow-md shadow-zinc-900/10 backdrop-blur-sm transition hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/95 dark:text-zinc-200 dark:shadow-black/30 dark:hover:bg-zinc-700"
+        >
+          <LocateFixed size={13} />
+          Follow playhead
+        </button>
+      )}
+      <TranscriptScrollIndicator
+        scrollRef={scrollRef}
+        contentRef={containerRef}
+        onUserScroll={unfollowPlayhead}
+      />
     </section>
   );
 }

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -147,7 +147,11 @@ export default function TranscriptPanel() {
   const importInputRef = useRef<HTMLInputElement>(null);
   // Playhead follow: auto-scroll while true; manual scroll turns it off.
   const followPlayheadRef = useRef(true);
+  /** Set by wheel/touch/rail before the matching scroll event. */
+  const userScrollGestureRef = useRef(false);
   const [followPlayhead, setFollowPlayhead] = useState(true);
+  /** Playhead outside the readable viewport — gates the Follow control. */
+  const [playheadOffscreen, setPlayheadOffscreen] = useState(false);
   /** Which way to jump to the playhead when unfollowed. */
   const [followDirection, setFollowDirection] = useState<"up" | "down">("down");
   const [correcting, setCorrecting] = useState<{
@@ -178,33 +182,57 @@ export default function TranscriptPanel() {
     freezeSelectionRef,
   });
 
-  const updateFollowDirection = useCallback(() => {
+  /** Measure whether the active word sits above/below the readable pane. */
+  const measurePlayheadAnchor = useCallback(() => {
     const scroller = scrollRef.current;
-    if (!scroller) return;
+    if (!scroller) return { offscreen: false as const };
     const { words, currentTime } = useEditorStore.getState();
     const activeId = findActiveWordId(words, currentTime);
-    if (activeId < 0) return;
+    if (activeId < 0) {
+      setPlayheadOffscreen(false);
+      return { offscreen: false as const };
+    }
     const el = containerRef.current?.querySelector(`[data-wid="${activeId}"]`);
-    if (!el) return;
+    if (!el) {
+      setPlayheadOffscreen(false);
+      return { offscreen: false as const };
+    }
     const wordRect = el.getBoundingClientRect();
     const scrollerRect = scroller.getBoundingClientRect();
     // Header overlays the top of the scroller (pt-10 / scroll-pt-10).
     const viewTop = scrollerRect.top + 40;
     const viewBottom = scrollerRect.bottom;
-    if (wordRect.bottom < viewTop) setFollowDirection("up");
-    else if (wordRect.top > viewBottom) setFollowDirection("down");
+    if (wordRect.bottom < viewTop) {
+      setPlayheadOffscreen(true);
+      setFollowDirection("up");
+      return { offscreen: true as const, direction: "up" as const };
+    }
+    if (wordRect.top > viewBottom) {
+      setPlayheadOffscreen(true);
+      setFollowDirection("down");
+      return { offscreen: true as const, direction: "down" as const };
+    }
+    setPlayheadOffscreen(false);
+    return { offscreen: false as const };
   }, []);
 
-  const unfollowPlayhead = useCallback(() => {
-    if (!followPlayheadRef.current) return;
-    followPlayheadRef.current = false;
-    setFollowPlayhead(false);
-    updateFollowDirection();
-  }, [updateFollowDirection]);
+  /** Rail / gesture hint — actual unfollow waits until scroll leaves the word. */
+  const userScrollGestureTimerRef = useRef(0);
+  const markUserScrollGesture = useCallback(() => {
+    const scroller = scrollRef.current;
+    if (!scroller || scroller.scrollHeight <= scroller.clientHeight + 1) return;
+    userScrollGestureRef.current = true;
+    // Keep the gesture armed across momentum / rail-drag scroll bursts.
+    window.clearTimeout(userScrollGestureTimerRef.current);
+    userScrollGestureTimerRef.current = window.setTimeout(() => {
+      userScrollGestureRef.current = false;
+    }, 150);
+  }, []);
 
   const resumeFollowPlayhead = useCallback(() => {
     followPlayheadRef.current = true;
     setFollowPlayhead(true);
+    setPlayheadOffscreen(false);
   }, []);
 
   // Clicking a word seeks — resume following so playback stays in view.
@@ -361,20 +389,33 @@ export default function TranscriptPanel() {
     return () => document.removeEventListener("keydown", handler);
   }, [selection, assigningSpeaker, correcting, openSpeakerAssign]);
 
-  // User scroll gestures pause playhead follow (not programmatic scrollIntoView).
-  // Native scrollbar is hidden — wheel/touch cover trackpads; the custom rail
-  // reports via onUserScroll. Avoid pointerdown here so word clicks don't unfollow.
+  // User scroll pauses follow only once the active word actually leaves view.
+  // Wheel over a non-scrollable pane is ignored (no Follow chip).
   useEffect(() => {
     const scroller = scrollRef.current;
     if (!scroller) return;
-    const onIntent = () => unfollowPlayhead();
-    scroller.addEventListener("wheel", onIntent, { passive: true });
-    scroller.addEventListener("touchmove", onIntent, { passive: true });
-    return () => {
-      scroller.removeEventListener("wheel", onIntent);
-      scroller.removeEventListener("touchmove", onIntent);
+    const onGesture = () => markUserScrollGesture();
+    const onScroll = () => {
+      if (!playing) return;
+      const { offscreen } = measurePlayheadAnchor();
+      if (userScrollGestureRef.current && offscreen) {
+        followPlayheadRef.current = false;
+        setFollowPlayhead(false);
+        return;
+      }
+      // Scrolled back onto the playhead (or programmatic nearest kept it in view).
+      if (!offscreen && !followPlayheadRef.current) resumeFollowPlayhead();
     };
-  }, [unfollowPlayhead]);
+    scroller.addEventListener("wheel", onGesture, { passive: true });
+    scroller.addEventListener("touchmove", onGesture, { passive: true });
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener("wheel", onGesture);
+      scroller.removeEventListener("touchmove", onGesture);
+      scroller.removeEventListener("scroll", onScroll);
+      window.clearTimeout(userScrollGestureTimerRef.current);
+    };
+  }, [markUserScrollGesture, measurePlayheadAnchor, resumeFollowPlayhead, playing]);
 
   // Keep the active word in view during playback while following.
   useEffect(() => {
@@ -383,16 +424,18 @@ export default function TranscriptPanel() {
     el?.scrollIntoView({ block: "nearest" });
   }, [activeWordId, playing, followPlayhead]);
 
-  // Keep the Follow button arrow pointed toward the active word.
+  // Refresh offscreen/direction as the playhead advances while unfollowed.
   useEffect(() => {
     if (followPlayhead || !playing || activeWordId < 0) return;
-    updateFollowDirection();
-    const scroller = scrollRef.current;
-    if (!scroller) return;
-    const onScroll = () => updateFollowDirection();
-    scroller.addEventListener("scroll", onScroll, { passive: true });
-    return () => scroller.removeEventListener("scroll", onScroll);
-  }, [followPlayhead, playing, activeWordId, updateFollowDirection]);
+    const { offscreen } = measurePlayheadAnchor();
+    if (!offscreen) resumeFollowPlayhead();
+  }, [
+    followPlayhead,
+    playing,
+    activeWordId,
+    measurePlayheadAnchor,
+    resumeFollowPlayhead,
+  ]);
 
   const busy = status === "preparing" || status === "transcribing";
 
@@ -645,7 +688,7 @@ export default function TranscriptPanel() {
       </div>
       {/* Gradient overlay — must match the transcript panel surface */}
       <div className="absolute z-10 pointer-events-none inset-x-0 bottom-0 w-full h-20 bg-gradient-to-t from-white to-transparent dark:from-zinc-900" />
-      {!followPlayhead && playing && activeWordId >= 0 && (
+      {!followPlayhead && playheadOffscreen && playing && activeWordId >= 0 && (
         <button
           type="button"
           onClick={resumeFollowPlayhead}
@@ -659,7 +702,7 @@ export default function TranscriptPanel() {
       <TranscriptScrollIndicator
         scrollRef={scrollRef}
         contentRef={containerRef}
-        onUserScroll={unfollowPlayhead}
+        onUserScroll={markUserScrollGesture}
       />
     </section>
   );

--- a/components/TranscriptScrollIndicator.tsx
+++ b/components/TranscriptScrollIndicator.tsx
@@ -374,7 +374,6 @@ export default function TranscriptScrollIndicator({
       const thumb = thumbRef.current;
       if (!scroller || !rail || !thumb) return;
       e.preventDefault();
-      onUserScroll?.();
 
       const railRect = rail.getBoundingClientRect();
       const thumbRect = thumb.getBoundingClientRect();
@@ -388,6 +387,7 @@ export default function TranscriptScrollIndicator({
 
       const drag = (clientY: number) => {
         if (travel <= 0) return;
+        onUserScroll?.();
         const y = clamp(clientY - railRect.top - grab, 0, travel);
         scroller.scrollTop = (y / travel) * range;
       };

--- a/components/TranscriptScrollIndicator.tsx
+++ b/components/TranscriptScrollIndicator.tsx
@@ -184,9 +184,12 @@ function topAt(anchors: Anchor[], time: number): number {
 export default function TranscriptScrollIndicator({
   scrollRef,
   contentRef,
+  onUserScroll,
 }: {
   scrollRef: RefObject<HTMLDivElement | null>;
   contentRef: RefObject<HTMLDivElement | null>;
+  /** Fired when the user drags or clicks the rail (not programmatic scroll). */
+  onUserScroll?: () => void;
 }) {
   const words = useEditorStore((s) => s.words);
   const starts = useMemo(() => {
@@ -371,6 +374,7 @@ export default function TranscriptScrollIndicator({
       const thumb = thumbRef.current;
       if (!scroller || !rail || !thumb) return;
       e.preventDefault();
+      onUserScroll?.();
 
       const railRect = rail.getBoundingClientRect();
       const thumbRect = thumb.getBoundingClientRect();
@@ -403,7 +407,7 @@ export default function TranscriptScrollIndicator({
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
     },
-    [scrollRef, bump]
+    [scrollRef, bump, onUserScroll]
   );
 
   return (

--- a/hooks/useTranscriptPlayheadFollow.ts
+++ b/hooks/useTranscriptPlayheadFollow.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import { useEditorStore } from "@/lib/store";
+import { findActiveWordId } from "@/lib/transcript";
+
+/** Matches the transcript panel's floating header (`h-10` / `pt-10` / `scroll-pt-10`). */
+const HEADER_H = 40;
+
+export type FollowDirection = "up" | "down";
+
+/**
+ * Keep the active transcript word in view during playback, but pause when the
+ * user scrolls it offscreen. Exposes a Follow control until they resume.
+ */
+export function useTranscriptPlayheadFollow({
+  scrollRef,
+  containerRef,
+  playing,
+  activeWordId,
+}: {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  containerRef: RefObject<HTMLDivElement | null>;
+  playing: boolean;
+  activeWordId: number;
+}) {
+  const followPlayheadRef = useRef(true);
+  /** Set by wheel/touch/rail before the matching scroll event. */
+  const userScrollGestureRef = useRef(false);
+  const userScrollGestureTimerRef = useRef(0);
+  const [followPlayhead, setFollowPlayhead] = useState(true);
+  /** Playhead outside the readable viewport — gates the Follow control. */
+  const [playheadOffscreen, setPlayheadOffscreen] = useState(false);
+  /** Which way to jump to the playhead when unfollowed. */
+  const [followDirection, setFollowDirection] =
+    useState<FollowDirection>("down");
+
+  /** Measure whether the active word sits above/below the readable pane. */
+  const measurePlayheadAnchor = useCallback(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return { offscreen: false as const };
+    const { words, currentTime } = useEditorStore.getState();
+    const activeId = findActiveWordId(words, currentTime);
+    if (activeId < 0) {
+      setPlayheadOffscreen(false);
+      return { offscreen: false as const };
+    }
+    const el = containerRef.current?.querySelector(`[data-wid="${activeId}"]`);
+    if (!el) {
+      setPlayheadOffscreen(false);
+      return { offscreen: false as const };
+    }
+    const wordRect = el.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+    const viewTop = scrollerRect.top + HEADER_H;
+    const viewBottom = scrollerRect.bottom;
+    if (wordRect.bottom < viewTop) {
+      setPlayheadOffscreen(true);
+      setFollowDirection("up");
+      return { offscreen: true as const, direction: "up" as const };
+    }
+    if (wordRect.top > viewBottom) {
+      setPlayheadOffscreen(true);
+      setFollowDirection("down");
+      return { offscreen: true as const, direction: "down" as const };
+    }
+    setPlayheadOffscreen(false);
+    return { offscreen: false as const };
+  }, [scrollRef, containerRef]);
+
+  /** Rail / gesture hint — actual unfollow waits until scroll leaves the word. */
+  const markUserScrollGesture = useCallback(() => {
+    const scroller = scrollRef.current;
+    if (!scroller || scroller.scrollHeight <= scroller.clientHeight + 1) return;
+    userScrollGestureRef.current = true;
+    // Keep the gesture armed across momentum / rail-drag scroll bursts.
+    window.clearTimeout(userScrollGestureTimerRef.current);
+    userScrollGestureTimerRef.current = window.setTimeout(() => {
+      userScrollGestureRef.current = false;
+    }, 150);
+  }, [scrollRef]);
+
+  const resumeFollowPlayhead = useCallback(() => {
+    followPlayheadRef.current = true;
+    setFollowPlayhead(true);
+    setPlayheadOffscreen(false);
+  }, []);
+
+  // User scroll pauses follow only once the active word actually leaves view.
+  // Wheel over a non-scrollable pane is ignored (no Follow chip).
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    const onGesture = () => markUserScrollGesture();
+    const onScroll = () => {
+      if (!playing) return;
+      const { offscreen } = measurePlayheadAnchor();
+      if (userScrollGestureRef.current && offscreen) {
+        followPlayheadRef.current = false;
+        setFollowPlayhead(false);
+        return;
+      }
+      // Scrolled back onto the playhead (or programmatic nearest kept it in view).
+      if (!offscreen && !followPlayheadRef.current) resumeFollowPlayhead();
+    };
+    scroller.addEventListener("wheel", onGesture, { passive: true });
+    scroller.addEventListener("touchmove", onGesture, { passive: true });
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener("wheel", onGesture);
+      scroller.removeEventListener("touchmove", onGesture);
+      scroller.removeEventListener("scroll", onScroll);
+      window.clearTimeout(userScrollGestureTimerRef.current);
+    };
+  }, [
+    scrollRef,
+    markUserScrollGesture,
+    measurePlayheadAnchor,
+    resumeFollowPlayhead,
+    playing,
+  ]);
+
+  // Keep the active word in view during playback while following.
+  useEffect(() => {
+    if (!playing || !followPlayhead || activeWordId < 0) return;
+    const el = containerRef.current?.querySelector(
+      `[data-wid="${activeWordId}"]`
+    );
+    el?.scrollIntoView({ block: "nearest" });
+  }, [activeWordId, playing, followPlayhead, containerRef]);
+
+  // Refresh offscreen/direction as the playhead advances while unfollowed.
+  useEffect(() => {
+    if (followPlayhead || !playing || activeWordId < 0) return;
+    const { offscreen } = measurePlayheadAnchor();
+    if (!offscreen) resumeFollowPlayhead();
+  }, [
+    followPlayhead,
+    playing,
+    activeWordId,
+    measurePlayheadAnchor,
+    resumeFollowPlayhead,
+  ]);
+
+  const showFollowControl =
+    !followPlayhead && playheadOffscreen && playing && activeWordId >= 0;
+
+  return {
+    showFollowControl,
+    followDirection,
+    resumeFollowPlayhead,
+    markUserScrollGesture,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
While video plays, the transcript keeps the active word in view via `scrollIntoView`. That sync is useful, but any manual scroll was immediately overridden on the next active-word change.

## Fix
- Track a **follow playhead** mode (on by default) in `useTranscriptPlayheadFollow`.
- User scroll (wheel/touch/rail) pauses follow **only once the active word leaves the viewport**.
- Wheel over a **non-scrollable** transcript is ignored — no Follow chip.
- The **Follow playhead** control appears only while playing, unfollowed, and the playhead is offscreen; its icon is an up/down arrow toward the active word.
- Clicking the control (or a transcript word) resumes auto-scroll. Scrolling back onto the playhead also resumes follow.

## Test plan
- [x] Play a long transcript — active word stays in view while following.
- [x] Scroll away during playback — position sticks; Follow playhead appears with correct arrow.
- [x] Wheel on a short, non-scrollable transcript — Follow playhead does **not** appear.
- [x] Tiny scroll that keeps the playhead in view — Follow playhead does **not** appear.
- [x] Click Follow playhead / click a word — resume sync.

## Demo
![No button when content fits](https://cursor.com/artifacts/c/art-513931a4-967e-4c26-88e3-17ab18dad991)
![Button only when scrolled away](https://cursor.com/artifacts/c/art-6b3c5e3d-11df-46aa-914f-5649a6782fcb)
![Up arrow toward playhead](https://cursor.com/artifacts/c/art-bd694621-6096-4fc0-814a-50dff910658c)
<a href="https://cursor.com/agents/bc-7fa02478-f522-45b0-a1b1-2582c08bfba8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftranscript-scroll-follow-demo.mp4"><img src="https://cursor.com/artifacts/c/art-4d4af0a5-8186-40fb-a9f3-c91373b9080b" alt="transcript-scroll-follow-demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fa02478-f522-45b0-a1b1-2582c08bfba8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fa02478-f522-45b0-a1b1-2582c08bfba8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

