### PR TITLE
Keep global shortcuts alive after a file picker

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -30,6 +30,7 @@ import ModelSelector, {
 } from "./ModelSelector";
 import ImportTranscriptOption from "./ImportTranscriptOption";
 import { MODEL_ORDER } from "@/lib/models";
+import { isTypingTarget } from "@/lib/keyboard";
 
 /** How long the desktop mode-change overlay stays up. Matches the macOS
  *  `setBounds(..., animate)` duration plus a small buffer so the layout
@@ -254,9 +255,7 @@ export default function Editor() {
   // (which would double-toggle playback and look like the hotkey "didn't work").
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
-        return;
+      if (isTypingTarget(e.target)) return;
       const s = useEditorStore.getState();
       if (e.code === "Space" && s.videoEl && !s.exportOpen) {
         e.preventDefault();

--- a/components/TranscriptPanel.tsx
+++ b/components/TranscriptPanel.tsx
@@ -42,6 +42,7 @@ import { useTranscriptPlayheadFollow } from "@/hooks/useTranscriptPlayheadFollow
 import { useWordAnchorFloating } from "@/hooks/useWordAnchorFloating";
 import { useCutRanges } from "@/hooks/useCutRanges";
 import { findActiveWordId, groupWordsBySpeaker } from "@/lib/transcript";
+import { isTypingTarget } from "@/lib/keyboard";
 
 const WordSpan = memo(function WordSpan({
   word,
@@ -306,9 +307,7 @@ export default function TranscriptPanel() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      const target = e.target as HTMLElement;
-      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
-        return;
+      if (isTypingTarget(e.target)) return;
       if (selectedWordIds.length === 0) return;
       e.preventDefault();
       clearSelection();
@@ -321,9 +320,7 @@ export default function TranscriptPanel() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "@" || e.metaKey || e.ctrlKey || e.altKey) return;
-      const target = e.target as HTMLElement;
-      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
-        return;
+      if (isTypingTarget(e.target)) return;
       if (!selection || assigningSpeaker || correcting) return;
       e.preventDefault();
       openSpeakerAssign();

--- a/lib/keyboard.ts
+++ b/lib/keyboard.ts
@@ -1,0 +1,14 @@
+/**
+ * True when a keystroke belongs to a text field rather than the global
+ * shortcuts. File inputs are excluded on purpose: the desktop File › Open
+ * Project… menu and the transcript Import label both click a hidden
+ * `<input type="file">`, which keeps focus after the picker closes — treating
+ * that as "typing" silently killed the spacebar play/pause hotkey.
+ */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  if (el.tagName === "TEXTAREA") return true;
+  return el.tagName === "INPUT" && (el as HTMLInputElement).type !== "file";
+}


### PR DESCRIPTION
## Problem

The space bar play/pause hotkey stopped working. The code was never removed — the guard in the global keydown handler was swallowing it.

`71d4168` added a persistent hidden `<input type="file">` (`components/Editor.tsx:401`) that the desktop **File › Open Project…** menu clicks. Clicking a file input focuses it, and it stays focused after the OS picker closes. The handler bails on any focused `<input>`, so from then on **every** global shortcut — space, `S`, ⌘Z, Delete — is dead for the rest of the session. The transcript **Import** label uses the same hidden-input trick and breaks them the same way.

## Fix

File inputs can't receive typed text, so they shouldn't count as a typing target.

- `lib/keyboard.ts` (new) — `isTypingTarget()`: contentEditable / `TEXTAREA` / `INPUT` except `type="file"`.
- `components/Editor.tsx` — global shortcut handler uses it.
- `components/TranscriptPanel.tsx` — the Escape and `@` handlers had the same copy-pasted guard and the same latent bug; both now use it.

## Testing

Typecheck and lint pass. Not yet verified end-to-end in the desktop app — repro is: open a project via the File menu, then press space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)