### PR TITLE
build: refresh runtime assets before builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "prebuild": "node scripts/copy-assets.mjs",
     "start": "next start",
     "lint": "eslint",
     "postinstall": "patch-package && node scripts/copy-assets.mjs",
@@ -24,7 +25,9 @@
     "typecheck:electron": "tsc -p electron/tsconfig.json --noEmit",
     "electron:dev": "npm run build:electron && concurrently -k -n next,electron -c cyan,magenta \"next dev\" \"node scripts/electron-dev.mjs\"",
     "export:web": "cross-env STATIC_EXPORT=1 next build",
+    "preexport:web": "node scripts/copy-assets.mjs",
     "export:desktop": "cross-env STATIC_EXPORT=1 NEXT_PUBLIC_ELECTRON=1 next build",
+    "preexport:desktop": "node scripts/copy-assets.mjs",
     "dist": "npm run export:desktop && npm run build:electron && electron-builder --config.npmRebuild=false",
     "release": "npm run export:desktop && npm run build:electron && electron-builder --publish always --config.npmRebuild=false",
     "cut:patch": "npm version patch -m \"Release v%s\" && git push --follow-tags",


### PR DESCRIPTION
Splits the runtime-asset build change out of #80 for focused review (4/4).

## Summary

- run the existing copy-assets script before a standard production build
- run the same step before both Web and Electron static exports
- prevent packaged FFmpeg core and ONNX Runtime WASM files from being missing or stale when postinstall was skipped or an existing checkout is reused

## Scope

This changes only three package scripts. Generated assets, speech models, dist output, and installers are not committed.

## Validation

- npm run build
- confirmed copy-assets refreshed FFmpeg core and ONNX Runtime WASM before the successful production build