### PR TITLE
Fix FCPXML import failing DTD validation in Final Cut Pro

### DIFF
--- a/lib/serializeTimeline.ts
+++ b/lib/serializeTimeline.ts
@@ -175,6 +175,23 @@ export function timelineExtension(format: TimelineExportFormat): string {
   return TIMELINE_FORMATS.find((f) => f.value === format)?.ext ?? format;
 }
 
+/**
+ * Drop `modDate` from the exported project.
+ *
+ * Final Cut Pro rejects the entire document with "DTD validation failed" when
+ * it cannot parse this attribute. The upstream writer stamps an IANA zone name
+ * (`2026-08-29 12:37:45 America/Los_Angeles`) where FCP wants a numeric UTC
+ * offset (`-0700`), and FCP 10.6.x additionally only accepts the clock format
+ * matching the user's system 12/24-hour setting. modDate is optional and we
+ * have nothing meaningful to put in it, so the safe answer is to omit it.
+ *
+ * Attribute values are XML-escaped by the writer, so `"` and `>` cannot appear
+ * inside one — matching up to the tag's `>` is safe even for odd file names.
+ */
+export function stripFcpxmlModDate(xml: string): string {
+  return xml.replace(/(<project\b[^>]*?)\s+modDate="[^"]*"/g, "$1");
+}
+
 export function serializeTimelineXml(
   options: TimelineExportOptions,
   format: Exclude<TimelineExportFormat, "aaf">
@@ -193,7 +210,15 @@ export function serializeTimelineXml(
     return writeXMEML(timeline);
   }
   if (format === "premiere") return writeXMEML(timeline);
-  return writeFCPXML(timeline);
+
+  // A single FCP asset-clip carries both the video and the audio of its asset.
+  // Our parallel V1/A1 tracks are the same media over the same ranges, so
+  // keeping both makes the writer attach A1 as connected clips in lane 1 —
+  // FCP imports that as a duplicate video overlay with doubled audio.
+  if (timeline.tracks.length > 1) {
+    timeline.tracks = timeline.tracks.filter((t) => t.kind === "video");
+  }
+  return stripFcpxmlModDate(writeFCPXML(timeline));
 }
 
 export async function serializeTimelineAaf(

--- a/tests/serialize-timeline-test.ts
+++ b/tests/serialize-timeline-test.ts
@@ -8,6 +8,7 @@ import {
   buildNleTimeline,
   mediaFileUrl,
   serializeTimelineXml,
+  stripFcpxmlModDate,
 } from "../lib/serializeTimeline";
 import {
   AAF_MAX_CLIPS,
@@ -134,7 +135,72 @@ async function main() {
   assert(fcpx.includes("<fcpxml"), "fcpxml root");
   assert(fcpx.includes("<spine>") || fcpx.includes("<spine "), "fcpxml spine");
   assert(fcpx.includes("asset-clip") || fcpx.includes("asset"), "fcpxml assets");
+  // FCP fails DTD validation on an unparseable modDate, so we omit it.
+  assert(!fcpx.includes("modDate"), "fcpxml has no modDate");
+  // V1/A1 are the same media over the same ranges; a single asset-clip per
+  // range carries both, so no duplicate connected clips in lane 1.
+  assert(!fcpx.includes("lane="), "fcpxml has no connected-clip lanes");
+  assert(
+    fcpx.match(/<asset-clip/g)?.length === keeps.length,
+    "one fcpxml asset-clip per keep range"
+  );
   console.log("fcpxml: ok");
+}
+
+{
+  // Audio-only projects have a single track and must still land on the spine.
+  const fcpx = serializeTimelineXml(
+    {
+      keepRanges: keeps,
+      duration: 5,
+      mediaFileName: "podcast.m4a",
+      frameRate: "30",
+      withVideo: false,
+      withAudio: true,
+    },
+    "fcpx"
+  );
+  assert(fcpx.includes('hasAudio="1"'), "fcpxml audio-only asset");
+  assert(!fcpx.includes('hasVideo="1"'), "fcpxml audio-only has no video");
+  assert(
+    fcpx.match(/<asset-clip/g)?.length === keeps.length,
+    "audio-only fcpxml asset-clips"
+  );
+  console.log("fcpxml audio-only: ok");
+}
+
+{
+  assert(
+    stripFcpxmlModDate('<project name="a" modDate="2026-01-01 00:00:00 UTC">') ===
+      '<project name="a">',
+    "strips modDate"
+  );
+  assert(
+    stripFcpxmlModDate('<project modDate="x" uid="u"/>') === '<project uid="u"/>',
+    "strips modDate mid-tag"
+  );
+  // Only the project tag; a clip named "modDate=..." must survive untouched.
+  const kept = '<asset-clip name="my modDate=&quot;x&quot; take.mp4"/>';
+  assert(stripFcpxmlModDate(kept) === kept, "leaves non-project tags alone");
+  console.log("strip modDate: ok");
+}
+
+{
+  // Premiere/Resolve still need the parallel audio track.
+  const premiere = serializeTimelineXml(
+    {
+      keepRanges: keeps,
+      duration: 5,
+      mediaFileName: "interview.mp4",
+      frameRate: "24",
+      withVideo: true,
+      withAudio: true,
+    },
+    "premiere"
+  );
+  assert(premiere.includes("<video>"), "premiere keeps video track");
+  assert(premiere.includes("<audio>"), "premiere keeps audio track");
+  console.log("xmeml tracks intact: ok");
 }
 
 {


### PR DESCRIPTION
## The bug

Jack reported that importing an exported FCPXML timeline into Final Cut Pro always fails:

> The XML document sent from application "(null)" could not be imported.
> DTD validation failed. (The data couldn't be read because it isn't in the correct format.)

His hunch about a 12-hour vs 24-hour date format was the right thread to pull.

## Cause

Two problems in the FCPXML we emit. Before:

```xml
<project name="interview" modDate="2026-08-29 12:35:09 America/Los_Angeles">
  <sequence ...>
    <spine>
      <asset-clip name="interview.mp4 1" ref="ra24740a9b9ee" offset="0s" duration="1/1s" start="0s">
        <asset-clip name="interview.mp4 1" ref="ra24740a9b9ee" offset="0s" duration="1/1s" start="0s" lane="1"/>
      </asset-clip>
```

**1. `modDate` is unparseable.** FCP wants a numeric UTC offset (`2026-08-29 12:35:09 -0700`); the upstream writer stamps an IANA zone name instead. A `modDate` FCP can't parse takes down the whole document with the generic DTD error. FCP 10.6.x is stricter still — [it only accepts the clock format matching the user's system 12/24-hour setting](https://getrecut.com/xml-document-could-not-be-imported/), so even a well-formed value is a coin flip. The attribute is optional and we have nothing meaningful to put there, so we drop it.

**2. Duplicate connected clips.** We hand the writer parallel V1/A1 tracks, which XMEML and AAF both need. But a single FCP `asset-clip` already carries the video *and* audio of its asset, so the writer turned A1 into connected clips in lane 1 — that imports as a duplicate video overlay with doubled audio. We now collapse to one track for the FCPXML path only.

## After

```xml
<project name="interview">
  <sequence duration="5/2s" format="r1" tcStart="0s" tcFormat="NDF" audioLayout="stereo" audioRate="48k">
    <spine>
      <asset-clip name="interview.mp4 1" ref="ra24740a9b9ee" offset="0s" duration="1/1s" start="0s"/>
      <asset-clip name="interview.mp4 2" ref="ra24740a9b9ee" offset="1/1s" duration="3/2s" start="2/1s"/>
    </spine>
```

Premiere/Resolve XMEML and AAF output are unchanged.

## Testing

`npm run test:timeline` passes, with new coverage for: no `modDate` in the output, one `asset-clip` per keep range with no `lane=` attributes, audio-only FCPXML projects still landing on the spine, `stripFcpxmlModDate` not touching non-`project` tags, and XMEML keeping both its tracks. `tsc --noEmit` and `eslint` are clean.

I could not verify the import in Final Cut Pro itself — it isn't installed here — so that check is still worth doing before release. The output is well-formed per `xmllint`, and both defects are independently confirmed against how real FCP-authored files look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)