### PR TITLE
Fail the export when ffmpeg wedges instead of hanging at 0%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Timeline export tests
         run: npm run test:timeline
 
+      - name: ffmpeg watchdog tests
+        run: npm run test:ffmpeg
+
       - name: Build Next.js
         run: npm run build
 

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -11,6 +11,7 @@ import {
   X,
 } from "lucide-react";
 import { useEditorStore } from "@/lib/store";
+import { reportError } from "@/lib/sentry";
 import { trackEvent } from "@/lib/telemetry";
 import { formatTime, getEditedDuration, getKeepRanges } from "@/lib/edits";
 import {
@@ -224,6 +225,11 @@ export default function ExportDialog() {
         ...(activeTab === "audio" ? {} : { resolution }),
       });
     } catch (err) {
+      // The message we show is friendly and lossy — "Export failed while
+      // rendering the video" says nothing about which of ffmpeg's failure modes
+      // it was. Send the original so the export path is visible in Sentry at
+      // all; until now only the crashes that escaped this catch were.
+      reportError(err, `export-${activeTab}`);
       setError(err instanceof Error ? err.message : en["error.export"]);
     } finally {
       setStatus("ready");

--- a/lib/ffmpeg.ts
+++ b/lib/ffmpeg.ts
@@ -22,6 +22,18 @@ const MOUNT_DIR = "/mnt_input";
  */
 const COPY_INPUT_MAX_BYTES = 256 * 1024 * 1024;
 
+/**
+ * How long `exec` may go without any log or progress event before we treat the
+ * core as wedged (see {@link execWithWatchdog}).
+ *
+ * This is a liveness budget, not a time limit: a genuinely slow 4K export runs
+ * for hours and resets the timer several times a second the whole way. It only
+ * has to clear the longest legitimate silence, which is the final mux —
+ * `-movflags +faststart` rewrites the entire output file after the last frame
+ * is encoded, and nothing is logged while it does.
+ */
+const EXEC_STALL_TIMEOUT_MS = 120_000;
+
 let ffmpegPromise: Promise<FFmpeg> | null = null;
 let writtenFor: File | null = null;
 /** Path `writtenFor`'s media is readable at, and whether it came from a mount. */
@@ -88,6 +100,69 @@ export async function releaseFFmpeg(): Promise<void> {
     (await pending).terminate();
   } catch {
     // Load failed or the worker is already gone — the heap went with it.
+  }
+}
+
+/**
+ * Run `ffmpeg.exec` under a liveness watchdog, so a wedged core fails instead
+ * of hanging.
+ *
+ * The multi-threaded core runs the filtergraph and the encoder on real
+ * pthreads. When one of those traps — reliably, when the fixed 1 GiB heap runs
+ * out — that thread dies and the main ffmpeg thread blocks on a futex it will
+ * never be woken from. Nothing reports this: the trap happens in a nested
+ * worker, so it never reaches the class worker's `onerror` (patched in, see
+ * `patches/README.md`), and the message protocol has no reply for "the core
+ * stopped existing". The `exec` promise simply never settles, which is what put
+ * export at "Rendering in your browser… 0%" forever.
+ *
+ * Silence is the signal. The core logs continuously while it is working — the
+ * encoder's status line alone lands several times a second — and `postMessage`
+ * from the worker still reaches us while its message thread is blocked inside
+ * `exec`. So a long enough gap with no log *and* no progress means the work has
+ * stopped, whatever killed it.
+ *
+ * Terminating is the only recovery: it kills the pthreads along with the
+ * worker, hands the gigabyte back, and makes the pending `exec` reject so the
+ * caller unblocks. The next export builds a fresh core.
+ *
+ * Exported, and `stallTimeoutMs` overridable, only so `tests/ffmpeg-watchdog-test.ts`
+ * can drive it against a stub — there is no way to wedge a real core on demand.
+ */
+export async function execWithWatchdog(
+  ffmpeg: FFmpeg,
+  args: string[],
+  stallTimeoutMs: number = EXEC_STALL_TIMEOUT_MS
+): Promise<number> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let stalled = false;
+  const beat = () => {
+    if (stalled) return;
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      stalled = true;
+      // Drop the singleton first (that part of releaseFFmpeg is synchronous) so
+      // the next export builds a fresh core, then kill this instance by hand:
+      // releaseFFmpeg skips the terminate if anything already swapped the
+      // singleton out, and skipping it here would leave us hung after all.
+      void releaseFFmpeg();
+      ffmpeg.terminate();
+    }, stallTimeoutMs);
+  };
+  ffmpeg.on("log", beat);
+  ffmpeg.on("progress", beat);
+  beat();
+  try {
+    return await ffmpeg.exec(args);
+  } catch (err) {
+    // The rejection we get here is `terminate()`'s, which describes our own
+    // recovery rather than what went wrong. Say what the user saw instead.
+    if (stalled) throw new Error(en["error.mediaEngineStalled"]);
+    throw err;
+  } finally {
+    clearTimeout(timer);
+    ffmpeg.off("log", beat);
+    ffmpeg.off("progress", beat);
   }
 }
 
@@ -178,7 +253,7 @@ export async function extractAudio(file: File): Promise<Float32Array | null> {
   ffmpeg.on("log", logHandler);
   let code: number;
   try {
-    code = await ffmpeg.exec([
+    code = await execWithWatchdog(ffmpeg, [
       "-i", input,
       "-vn",
       "-ac", "1",
@@ -311,7 +386,7 @@ export async function exportVideo(
             "-movflags", "+faststart",
           ];
 
-    const code = await ffmpeg.exec([
+    const code = await execWithWatchdog(ffmpeg, [
       "-i", input,
       "-filter_complex", filter,
       "-map", videoMap,
@@ -375,7 +450,7 @@ export async function exportAudio(
           ? ["-c:a", "pcm_s16le"]
           : ["-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart"];
 
-    const code = await ffmpeg.exec([
+    const code = await execWithWatchdog(ffmpeg, [
       "-i", input,
       "-filter_complex", filter,
       "-map", "[outa]",

--- a/lib/i18n/messages/de.ts
+++ b/lib/i18n/messages/de.ts
@@ -192,6 +192,7 @@ export const de: Record<MessageKey, string> = {
   "error.selectModel": "Wähle ein Sprachmodell zum Transkribieren aus.",
   "error.workerCrashed": "Transkriptions-Worker ist abgestürzt.",
   "error.mediaEngineNetwork": "Die Medien-Engine konnte nicht geladen werden — die Verbindung wurde unterbrochen. Prüfe deine Internetverbindung und versuche es erneut.",
+  "error.mediaEngineStalled": "Die Medien-Engine hat nicht mehr reagiert und wurde neu gestartet. Schließe andere Apps und Tabs, um Speicher freizugeben, und versuche es erneut.",
   "error.processFile": "Diese Datei konnte nicht verarbeitet werden.",
   "error.extractAudio": "Audio konnte aus dieser Datei nicht extrahiert werden.",
   "error.nothingToExport": "Alles wurde gelöscht — nichts zu exportieren.",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -192,6 +192,8 @@ export const en = {
   "error.workerCrashed": "Transcription worker crashed.",
   "error.mediaEngineNetwork":
     "Couldn't load the media engine — the connection dropped. Check your internet and try again.",
+  "error.mediaEngineStalled":
+    "The media engine stopped responding and was restarted. Close other apps and tabs to free up memory, then try again.",
   "error.processFile": "Failed to process this file.",
   "error.extractAudio": "Could not extract audio from this file.",
   "error.nothingToExport": "Everything has been deleted — nothing to export.",

--- a/lib/i18n/messages/es.ts
+++ b/lib/i18n/messages/es.ts
@@ -192,6 +192,7 @@ export const es: Record<MessageKey, string> = {
   "error.selectModel": "Selecciona un modelo de voz para transcribir.",
   "error.workerCrashed": "El worker de transcripción falló.",
   "error.mediaEngineNetwork": "No se pudo cargar el motor multimedia — se cortó la conexión. Revisa tu internet e inténtalo de nuevo.",
+  "error.mediaEngineStalled": "El motor multimedia dejó de responder y se reinició. Cierra otras apps y pestañas para liberar memoria e inténtalo de nuevo.",
   "error.processFile": "No se pudo procesar este archivo.",
   "error.extractAudio": "No se pudo extraer audio de este archivo.",
   "error.nothingToExport": "Todo se ha eliminado — no hay nada que exportar.",

--- a/lib/i18n/messages/fr.ts
+++ b/lib/i18n/messages/fr.ts
@@ -192,6 +192,7 @@ export const fr: Record<MessageKey, string> = {
   "error.selectModel": "Sélectionnez un modèle vocal pour transcrire.",
   "error.workerCrashed": "Le worker de transcription a planté.",
   "error.mediaEngineNetwork": "Impossible de charger le moteur multimédia — la connexion a été interrompue. Vérifiez votre connexion internet et réessayez.",
+  "error.mediaEngineStalled": "Le moteur multimédia ne répondait plus et a été redémarré. Fermez d’autres applications et onglets pour libérer de la mémoire, puis réessayez.",
   "error.processFile": "Impossible de traiter ce fichier.",
   "error.extractAudio": "Impossible d’extraire l’audio de ce fichier.",
   "error.nothingToExport": "Tout a été supprimé — rien à exporter.",

--- a/lib/i18n/messages/ja.ts
+++ b/lib/i18n/messages/ja.ts
@@ -192,6 +192,7 @@ export const ja: Record<MessageKey, string> = {
   "error.selectModel": "文字起こしに使う音声モデルを選択してください。",
   "error.workerCrashed": "文字起こしワーカーがクラッシュしました。",
   "error.mediaEngineNetwork": "メディアエンジンを読み込めませんでした — 接続が切れました。インターネット接続を確認して、もう一度お試しください。",
+  "error.mediaEngineStalled": "メディアエンジンが応答しなくなったため再起動しました。他のアプリやタブを閉じてメモリを空けてから、もう一度お試しください。",
   "error.processFile": "このファイルを処理できませんでした。",
   "error.extractAudio": "このファイルから音声を抽出できませんでした。",
   "error.nothingToExport": "すべて削除されています — 書き出すものがありません。",

--- a/lib/i18n/messages/ko.ts
+++ b/lib/i18n/messages/ko.ts
@@ -192,6 +192,7 @@ export const ko: Record<MessageKey, string> = {
   "error.selectModel": "자막을 만들 음성 모델을 선택하세요.",
   "error.workerCrashed": "자막 생성 워커가 충돌했습니다.",
   "error.mediaEngineNetwork": "미디어 엔진을 불러오지 못했습니다 — 연결이 끊겼습니다. 인터넷을 확인한 뒤 다시 시도하세요.",
+  "error.mediaEngineStalled": "미디어 엔진이 응답하지 않아 다시 시작했습니다. 다른 앱과 탭을 닫아 메모리를 확보한 뒤 다시 시도하세요.",
   "error.processFile": "이 파일을 처리하지 못했습니다.",
   "error.extractAudio": "이 파일에서 오디오를 추출할 수 없습니다.",
   "error.nothingToExport": "모든 내용이 삭제되었습니다 — 내보낼 항목이 없습니다.",

--- a/lib/i18n/messages/pt.ts
+++ b/lib/i18n/messages/pt.ts
@@ -192,6 +192,7 @@ export const pt: Record<MessageKey, string> = {
   "error.selectModel": "Selecione um modelo de voz para transcrever.",
   "error.workerCrashed": "O worker de transcrição falhou.",
   "error.mediaEngineNetwork": "Não foi possível carregar o motor de mídia — a conexão caiu. Verifique sua internet e tente de novo.",
+  "error.mediaEngineStalled": "O motor de mídia parou de responder e foi reiniciado. Feche outros apps e abas para liberar memória e tente de novo.",
   "error.processFile": "Não foi possível processar este arquivo.",
   "error.extractAudio": "Não foi possível extrair áudio deste arquivo.",
   "error.nothingToExport": "Tudo foi excluído — não há nada para exportar.",

--- a/lib/i18n/messages/zh-CN.ts
+++ b/lib/i18n/messages/zh-CN.ts
@@ -192,6 +192,8 @@ export const zhCN: Record<MessageKey, string> = {
   "error.workerCrashed": "转录进程发生崩溃。",
   "error.mediaEngineNetwork":
     "媒体引擎加载失败，网络连接已中断。请检查网络后重试。",
+  "error.mediaEngineStalled":
+    "媒体引擎停止响应，已重新启动。请关闭其他应用和标签页以释放内存，然后重试。",
   "error.processFile": "无法处理此文件。",
   "error.extractAudio": "无法从此文件提取音频。",
   "error.nothingToExport": "所有内容都已删除，没有可导出的内容。",

--- a/lib/i18n/messages/zh-TW.ts
+++ b/lib/i18n/messages/zh-TW.ts
@@ -191,6 +191,7 @@ export const zhTW: Record<MessageKey, string> = {
   "error.selectModel": "請選擇要用來轉錄的語音模型。",
   "error.workerCrashed": "轉錄 worker 已當機。",
   "error.mediaEngineNetwork": "無法載入媒體引擎 — 連線中斷。請檢查網路後再試一次。",
+  "error.mediaEngineStalled": "媒體引擎停止回應，已重新啟動。請關閉其他應用程式與分頁以釋放記憶體，然後再試一次。",
   "error.processFile": "無法處理此檔案。",
   "error.extractAudio": "無法從此檔案擷取音訊。",
   "error.nothingToExport": "所有內容都已刪除 — 沒有可匯出的內容。",

--- a/lib/i18n/runtimeMessages.ts
+++ b/lib/i18n/runtimeMessages.ts
@@ -22,6 +22,7 @@ const runtimeMessageKeyList = [
   "error.selectModel",
   "error.workerCrashed",
   "error.mediaEngineNetwork",
+  "error.mediaEngineStalled",
   "error.processFile",
   "error.extractAudio",
   "error.nothingToExport",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chatoctopus/timeline": "^0.3.0",
         "@ffmpeg/core-mt": "^0.12.10",
-        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/ffmpeg": "0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "@floating-ui/react": "^0.27.20",
         "@huggingface/transformers": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint",
     "test:i18n": "tsx tests/i18n-test.ts",
     "test:timeline": "tsx tests/serialize-timeline-test.ts",
+    "test:ffmpeg": "tsx tests/ffmpeg-watchdog-test.ts",
     "postinstall": "patch-package && node scripts/copy-assets.mjs",
     "build:electron": "node scripts/build-electron.mjs",
     "typecheck:electron": "tsc -p electron/tsconfig.json --noEmit",
@@ -37,7 +38,7 @@
   "dependencies": {
     "@chatoctopus/timeline": "^0.3.0",
     "@ffmpeg/core-mt": "^0.12.10",
-    "@ffmpeg/ffmpeg": "^0.12.15",
+    "@ffmpeg/ffmpeg": "0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "@floating-ui/react": "^0.27.20",
     "@huggingface/transformers": "4.2.0",

--- a/patches/@ffmpeg+ffmpeg+0.12.15.patch
+++ b/patches/@ffmpeg+ffmpeg+0.12.15.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/@ffmpeg/ffmpeg/dist/esm/classes.js b/node_modules/@ffmpeg/ffmpeg/dist/esm/classes.js
+index fae4753..625b7f7 100644
+--- a/node_modules/@ffmpeg/ffmpeg/dist/esm/classes.js
++++ b/node_modules/@ffmpeg/ffmpeg/dist/esm/classes.js
+@@ -20,11 +20,31 @@ export class FFmpeg {
+     #logEventCallbacks = [];
+     #progressEventCallbacks = [];
+     loaded = false;
++    /**
++     * Reject every in-flight request. Used when the worker dies outright, which
++     * the message protocol has no way to report: without this the promises stay
++     * pending forever and callers hang with no error.
++     */
++    #failAllPending = (reason) => {
++        for (const id of Object.keys(this.#rejects)) {
++            this.#rejects[id](reason);
++            delete this.#rejects[id];
++            delete this.#resolves[id];
++        }
++    };
+     /**
+      * register worker message event handlers.
+      */
+     #registerHandlers = () => {
+         if (this.#worker) {
++            // Deliberately not preventDefault()-ing: the error should still
++            // reach the page's global handler so crash reporting can see it.
++            this.#worker.onerror = (event) => {
++                this.#failAllPending(new Error(event.message || "ffmpeg worker crashed"));
++            };
++            this.#worker.onmessageerror = () => {
++                this.#failAllPending(new Error("ffmpeg worker sent a message that could not be deserialized"));
++            };
+             this.#worker.onmessage = ({ data: { id, type, data }, }) => {
+                 switch (type) {
+                     case FFMessageType.LOAD:

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,8 +6,9 @@ fails loudly rather than silently reverting to the buggy behaviour.
 **Patched dependencies are pinned to an exact version in `package.json`, not a
 caret range.** A patch filename carries the version it was cut against, and on a
 mismatch `patch-package` only *warns* — so a range would let a minor bump quietly
-drop the fix. That matters more than usual here: the unpatched failure mode below
-is a silently truncated transcript, not an error. When bumping
+drop the fix. That matters more than usual here, because neither unpatched
+failure mode below announces itself: one is a silently truncated transcript, the
+other an export that hangs forever instead of erroring. When bumping
 `@huggingface/transformers`, re-cut the patch (`npx patch-package
 @huggingface/transformers`) and re-run the CrisperWhisper models against a clip
 containing a filler.
@@ -68,3 +69,41 @@ already does. Also:
 **Upstreaming.** Worth a PR — the fix is small and the tokenizer already computes
 the correct bound. Until then this patch is required for the CrisperWhisper
 entries in `lib/models.ts` to work at all.
+
+## `@ffmpeg/ffmpeg` — reject in-flight calls when the worker dies
+
+**Upstream bug.** `FFmpeg` tracks every request in `#resolves` / `#rejects` keyed
+by message id, and the only thing that ever settles them is a reply from the
+worker. `#registerHandlers` installs `worker.onmessage` and nothing else — no
+`onerror`, no `onmessageerror`. The worker's own `self.onmessage` has a
+`try`/`catch` that posts an `ERROR` reply, so *synchronous* failures on the
+worker's message thread do report back. Everything else does not:
+
+- an emscripten `pthread` trapping (the multi-threaded core runs the filtergraph
+  and x264 on real threads, and their errors do not surface on the class
+  worker's message thread);
+- the browser killing the worker under memory pressure;
+- any async rejection outside the awaited path.
+
+In all three the promise stays pending forever. `FFmpeg.terminate()` is the only
+code that clears `#rejects`, and a caller stuck awaiting `exec()` never gets to
+call it.
+
+**How it broke Rescript.** Export sat at "Rendering in your browser… 0%"
+indefinitely with no error — the dialog has no timeout of its own, so the run
+never ended and never failed. The underlying crash *was* reaching Sentry as an
+unhandled `RuntimeError: memory access out of bounds`, tagged to no stage,
+because it never travelled through any of our `catch` blocks.
+
+**The patch.** Adds `#failAllPending(reason)` and wires it to `worker.onerror`
+and `worker.onmessageerror`, so a dead worker rejects every outstanding call
+instead of stranding it. It deliberately does *not* `preventDefault()` the error
+event — the crash should still reach the global handler so Sentry keeps seeing
+it.
+
+This covers the class worker dying. A trap inside a nested emscripten pthread
+does not bubble to the parent `Worker`, so `lib/ffmpeg.ts` also runs a liveness
+watchdog over `exec()`; see the comment on `execWithWatchdog` there.
+
+**Upstreaming.** Worth a PR — this is a bug in any consumer, not something
+specific to Rescript.

--- a/tests/ffmpeg-watchdog-test.ts
+++ b/tests/ffmpeg-watchdog-test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression: a wedged ffmpeg core must fail the export, not hang it.
+ *
+ * ffmpeg.wasm can stop making progress without ever settling the `exec`
+ * promise — most often a pthread trapping when the core's fixed 1 GiB heap runs
+ * out, which kills that thread and leaves the main one blocked on a futex.
+ * `execWithWatchdog` treats a long silence as a wedge and terminates the
+ * worker to force the rejection. That is unreproducible against a real core, so
+ * the contract is pinned here against a stub that can hang on demand.
+ */
+import type { FFmpeg } from "@ffmpeg/ffmpeg";
+import { execWithWatchdog } from "../lib/ffmpeg";
+import { en } from "../lib/i18n/messages/en";
+
+function assert(value: unknown, message: string): asserts value {
+  if (!value) throw new Error(message);
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type Listener = () => void;
+
+/**
+ * Minimal stand-in for the parts of `FFmpeg` the watchdog touches. `terminate`
+ * rejects the in-flight `exec` exactly as the real class does, which is the
+ * mechanism the watchdog relies on to unblock its caller.
+ */
+class StubFFmpeg {
+  terminated = 0;
+  lastArgs: string[] | null = null;
+  #listeners: Listener[] = [];
+  #rejectExec: ((reason: Error) => void) | null = null;
+
+  on(_event: string, callback: Listener) {
+    this.#listeners.push(callback);
+  }
+
+  off(_event: string, callback: Listener) {
+    this.#listeners = this.#listeners.filter((f) => f !== callback);
+  }
+
+  /** Emit a log/progress event, i.e. prove the core is still alive. */
+  beat() {
+    for (const listener of [...this.#listeners]) listener();
+  }
+
+  terminate() {
+    this.terminated++;
+    this.#rejectExec?.(new Error("called FFmpeg.terminate()"));
+    this.#rejectExec = null;
+  }
+
+  /** Never resolves on its own; only `terminate` can end it. */
+  exec(args: string[]): Promise<number> {
+    this.lastArgs = args;
+    return new Promise((_resolve, reject) => {
+      this.#rejectExec = reject;
+    });
+  }
+
+  asFFmpeg() {
+    return this as unknown as FFmpeg;
+  }
+}
+
+async function expectRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  throw new Error("expected a rejection");
+}
+
+/** Short enough to keep the suite quick, long enough to survive CI jitter. */
+const TIMEOUT = 60;
+
+async function main() {
+  // A run that finishes normally is untouched: no terminate, exit code preserved.
+  {
+    const stub = new StubFFmpeg();
+    stub.exec = async () => 0;
+    const code = await execWithWatchdog(stub.asFFmpeg(), ["-i", "in"], TIMEOUT);
+    assert(code === 0, "healthy exec returns its exit code");
+    assert(stub.terminated === 0, "healthy exec is not terminated");
+  }
+
+  // Silence past the budget: terminate the worker and report the stall, not
+  // terminate()'s own "called FFmpeg.terminate()" message.
+  {
+    const stub = new StubFFmpeg();
+    const err = await expectRejection(
+      execWithWatchdog(stub.asFFmpeg(), ["-i", "in"], TIMEOUT)
+    );
+    assert(stub.lastArgs?.join(" ") === "-i in", "args reach exec unchanged");
+    assert(err instanceof Error, "stall rejects with an Error");
+    assert(
+      (err as Error).message === en["error.mediaEngineStalled"],
+      "stall reports the localizable stall message"
+    );
+    assert(stub.terminated >= 1, "stall terminates the wedged worker");
+  }
+
+  // A slow-but-alive export must survive well past the budget: each log or
+  // progress event restarts the clock.
+  {
+    const stub = new StubFFmpeg();
+    const running = execWithWatchdog(stub.asFFmpeg(), ["-i", "in"], TIMEOUT);
+    for (let i = 0; i < 6; i++) {
+      await sleep(TIMEOUT / 2);
+      stub.beat();
+    }
+    assert(stub.terminated === 0, "heartbeats keep a slow export alive");
+    stub.terminate();
+    await expectRejection(running);
+  }
+
+  // ffmpeg's own failures pass through untouched — replacing them with the stall
+  // message would bury the real cause.
+  {
+    const stub = new StubFFmpeg();
+    const boom = new Error("ffmpeg said no");
+    stub.exec = async () => {
+      throw boom;
+    };
+    const err = await expectRejection(
+      execWithWatchdog(stub.asFFmpeg(), ["-i", "in"], TIMEOUT)
+    );
+    assert(err === boom, "a real ffmpeg error is not masked by the watchdog");
+    assert(stub.terminated === 0, "a real ffmpeg error does not terminate");
+  }
+
+  // The timer must not outlive the call: a leaked one would terminate the core
+  // mid-way through the *next* export.
+  {
+    const stub = new StubFFmpeg();
+    stub.exec = async () => 0;
+    await execWithWatchdog(stub.asFFmpeg(), ["-i", "in"], TIMEOUT);
+    await sleep(TIMEOUT * 3);
+    assert(stub.terminated === 0, "watchdog timer is cleared once exec settles");
+  }
+
+  console.log("ALL FFMPEG WATCHDOG TESTS PASSED");
+}
+
+void main();


### PR DESCRIPTION
Two Discord reports of export failing: one stuck at "Rendering in your browser… 0%" forever (Snapdragon ARM Windows), one erroring out (Apple M2). This PR fixes the *hang*. The underlying memory pressure is tracked separately.

## Why it hangs

`@ffmpeg/ffmpeg@0.12.15`'s `FFmpeg` class tracks every request in `#resolves`/`#rejects` and settles them only from `worker.onmessage`. `#registerHandlers` installs no `onerror` and no `onmessageerror`, so a worker that dies strands every in-flight call. `terminate()` is the only other thing that clears `#rejects`, and a caller stuck awaiting `exec()` never gets to call it.

Sentry corroborates: the crash *was* arriving, as an **unhandled** `RuntimeError: memory access out of bounds` tagged to no stage. That is the tell — it never travelled through any of our `catch` blocks.

But `worker.onerror` alone doesn't cover the case actually biting here. The multi-threaded core runs the filtergraph and x264 on real pthreads, which live in **nested** workers; their traps never bubble to the parent `Worker`. When one dies, the main ffmpeg thread blocks on a futex it will never be woken from, and the class worker is still perfectly healthy — it's just blocked inside a synchronous `exec`.

## What changed

**`patches/@ffmpeg+ffmpeg+0.12.15.patch`** — adds `#failAllPending` wired to `worker.onerror` / `onmessageerror`. Covers the class worker dying (browser OOM-kill, async rejection off the awaited path). Deliberately does not `preventDefault()`, so crash reporting still sees the error. Worth upstreaming; it's a bug in any consumer.

**`execWithWatchdog` in `lib/ffmpeg.ts`** — covers everything else. The core logs continuously while it works (the encoder status line alone lands several times a second), and `postMessage` still reaches us while the worker's message thread is blocked, so silence is a reliable wedge signal. 120s with no log *and* no progress → terminate, which frees the gigabyte and forces the pending `exec` to reject.

It's a liveness budget, not a time limit — a genuinely slow 4K export runs for hours and resets the timer the whole way. The budget only has to clear the longest legitimate silence, which is `-movflags +faststart` rewriting the output after the last frame.

Applied to audio extraction too, where the same wedge hangs import at "Extracting audio…".

**Sentry reporting on handled export failures.** The export path was invisible in Sentry except for crashes that escaped the catch, so the graceful failures — ffmpeg exiting non-zero, which is the M2 report — showed up nowhere at all.

**`@ffmpeg/ffmpeg` pinned to an exact version.** Required for patched deps per `patches/README.md`: on a version mismatch patch-package only *warns*, so a caret range would let a minor bump silently drop the fix.

## Testing

`tests/ffmpeg-watchdog-test.ts` (new, wired into CI) drives the watchdog against a stub that can hang on demand — a real core can't be wedged to order. Covers: healthy exec untouched, stall terminates and reports, heartbeats keep a slow export alive well past the budget, ffmpeg's own errors pass through unmasked, and the timer doesn't outlive the call (a leak would kill the *next* export).

Lint, typecheck, i18n, timeline tests and `next build` all pass. Patch verified to apply on a clean install.

## Not covered here

The 1 GiB ceiling itself. `ffmpeg-core.wasm` hard-declares `(memory 16384 16384 shared)` — min == max, so the `INITIAL_MEMORY` override in `ffmpeg-core.js` is a dead end and it can't be raised without rebuilding the core. Falling back to the single-threaded `@ffmpeg/core` (growable, 32 MiB → 2 GiB) and reworking the `trim`+`concat` filtergraph for high cut counts are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)